### PR TITLE
Fixed CVE-2019-10910

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.1",
         "symfony/console": "^3.0 || ^4.0",
-        "symfony/dependency-injection": "^3.0 || ^4.0",
+        "symfony/dependency-injection": "^3.0 || ^4.1.12",
         "symfony/process": "^3.0 || ^4.0",
         "webmozart/assert": "^1.5",
         "psr/log": "^1.1"


### PR DESCRIPTION
Fixed CVE-2019-10910 by upgrading the symfony/dependency-injection dependency.