### PR TITLE
Fixed performance problems when using multiprocessing

### DIFF
--- a/src/ProcessLauncher.php
+++ b/src/ProcessLauncher.php
@@ -101,8 +101,8 @@ class ProcessLauncher
                     break;
                 }
 
-                // 100ms
-                usleep(100000);
+                // 1ms
+                usleep(1000);
             }
 
             // Stream the data segment to the process' input stream
@@ -118,8 +118,8 @@ class ProcessLauncher
         while (count($this->runningProcesses) > 0) {
             $this->freeTerminatedProcesses();
 
-            // 100ms
-            usleep(100000);
+            // 1ms
+            usleep(1000);
         }
     }
 


### PR DESCRIPTION
Currently, running commands with multiprocessing turned on can have a large performance overhead when starting processes for new segments. Reducing the waiting time after terminating processes greatly reduces this problem.