### PR TITLE
Use child processes even if number of processes is only one

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -295,6 +295,7 @@ trait Parallelization
     {
         $this->runBeforeFirstCommand($input, $output);
 
+        $numberOfProcessesDefined = null !== $input->getOption('processes');
         $numberOfProcesses = (int) $input->getOption('processes');
         $hasItem = (bool) $input->getArgument('item');
         $items = $hasItem ? [$input->getArgument('item')] : $this->fetchItems($input);
@@ -347,7 +348,7 @@ trait Parallelization
         $progressBar->setFormat('debug');
         $progressBar->start();
 
-        if ($count <= $segmentSize || 1 === $numberOfProcesses) {
+        if ($count <= $segmentSize || (1 === $numberOfProcesses && !$numberOfProcessesDefined)) {
             // Run in the master process
 
             $itemsChunks = array_chunk(

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -300,7 +300,7 @@ trait Parallelization
         $hasItem = (bool) $input->getArgument('item');
         $items = $hasItem ? [$input->getArgument('item')] : $this->fetchItems($input);
         $count = count($items);
-        $segmentSize = 1 === $numberOfProcesses ? $count : $this->getSegmentSize();
+        $segmentSize = 1 === $numberOfProcesses && !$numberOfProcessesDefined ? $count : $this->getSegmentSize();
         $batchSize = $this->getBatchSize();
         $rounds = 1 === $numberOfProcesses ? 1 : ceil($count * 1.0 / $segmentSize);
         $batches = ceil($segmentSize * 1.0 / $batchSize) * $rounds;

--- a/tests/ParallelizationIntegrationTest.php
+++ b/tests/ParallelizationIntegrationTest.php
@@ -119,6 +119,34 @@ EOF
         );
     }
 
+    public function test_it_can_run_the_command_with_one_process_as_child_process(): void
+    {
+        $this->commandTester->execute(
+            [
+                'command' => 'import:movies',
+                '--processes' => 1,
+            ],
+            ['interactive' => true]
+        );
+
+        $actual = $this->getOutput();
+
+        $this->assertSame(
+            <<<'EOF'
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
+
+ 0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
+ 2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
+
+Processed 2 movies.
+
+EOF
+            ,
+            $actual,
+            'Expected logs to be identical'
+        );
+    }
+
     private function getOutput(): string
     {
         $output = $this->commandTester->getDisplay(true);

--- a/tests/ParallelizationIntegrationTest.php
+++ b/tests/ParallelizationIntegrationTest.php
@@ -77,7 +77,7 @@ class ParallelizationIntegrationTest extends TestCase
 
         $this->assertSame(
             <<<'EOF'
-Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -133,7 +133,7 @@ EOF
 
         $this->assertSame(
             <<<'EOF'
-Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB


### PR DESCRIPTION
Solves issue #14 

@theofidry Gave it a shot and I think I already have it. But I'm not happy with the test as it doesn't really check if a child process is used and I don't see how I can validate that at the moment. We could extend the existing output to the command to also include whether child processes are spawned or not. What do you think?