### PR TITLE
Added support for Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
     include:
         - php: '7.2'
-          env: PREFER_LOWEST='true'
+          env: PREFER_LOWEST='--prefer-lowest'
         - php: '7.3'
     fast_finish: true
 
@@ -24,7 +24,7 @@ before_install:
     - composer validate --strict
 
 install:
-    - composer install $COMPOSER_FLAGS
+    - composer update $COMPOSER_FLAGS $PREFER_LOWEST
 
 script:
     - make test

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 
     "require": {
         "php": "^7.1",
-        "symfony/console": "^4.1",
+        "symfony/console": "^3.0 || ^4.0",
         "symfony/dependency-injection": "^3.0 || ^4.1.12",
         "symfony/process": "^3.0 || ^4.0",
         "webmozart/assert": "^1.5",

--- a/tests/ParallelizationIntegrationTest.php
+++ b/tests/ParallelizationIntegrationTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization;
 
 use PHPUnit\Framework\TestCase;
+use function method_exists;
 use function preg_replace;
 use function str_replace;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -75,8 +76,25 @@ class ParallelizationIntegrationTest extends TestCase
 
         $actual = $this->getOutput();
 
-        $this->assertSame(
-            <<<'EOF'
+        if ($this->isSymfony3()) {
+            $this->assertSame(
+                <<<'EOF'
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+
+ 0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
+ 1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
+ 2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
+
+Processed 2 movies.
+
+EOF
+                ,
+                $actual,
+                'Expected logs to be identical'
+            );
+        } else {
+            $this->assertSame(
+                <<<'EOF'
 Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
@@ -85,10 +103,11 @@ Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 pr
 Processed 2 movies.
 
 EOF
-            ,
-            $actual,
-            'Expected logs to be identical'
-        );
+                ,
+                $actual,
+                'Expected logs to be identical'
+            );
+        }
     }
 
     public function test_it_can_run_the_command_with_multiple_processes(): void
@@ -103,8 +122,25 @@ EOF
 
         $actual = $this->getOutput();
 
-        $this->assertSame(
-        <<<'EOF'
+        if ($this->isSymfony3()) {
+            $this->assertSame(
+                <<<'EOF'
+Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 processes
+
+ 0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
+ 1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
+ 2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
+
+Processed 2 movies.
+
+EOF
+                ,
+                $actual,
+                'Expected logs to be identical'
+            );
+        } else {
+            $this->assertSame(
+                <<<'EOF'
 Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 processes
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
@@ -113,10 +149,11 @@ Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 p
 Processed 2 movies.
 
 EOF
-            ,
-            $actual,
-            'Expected logs to be identical'
-        );
+                ,
+                $actual,
+                'Expected logs to be identical'
+            );
+        }
     }
 
     public function test_it_can_run_the_command_with_one_process_as_child_process(): void
@@ -131,8 +168,25 @@ EOF
 
         $actual = $this->getOutput();
 
-        $this->assertSame(
-            <<<'EOF'
+        if ($this->isSymfony3()) {
+            $this->assertSame(
+                <<<'EOF'
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+
+ 0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
+ 1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
+ 2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
+
+Processed 2 movies.
+
+EOF
+                ,
+                $actual,
+                'Expected logs to be identical'
+            );
+        } else {
+            $this->assertSame(
+                <<<'EOF'
 Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
@@ -141,10 +195,11 @@ Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 pr
 Processed 2 movies.
 
 EOF
-            ,
-            $actual,
-            'Expected logs to be identical'
-        );
+                ,
+                $actual,
+                'Expected logs to be identical'
+            );
+        }
     }
 
     private function getOutput(): string
@@ -158,5 +213,10 @@ EOF
         );
 
         return str_replace(PHP_EOL, "\n", $output);
+    }
+
+    private function isSymfony3(): bool
+    {
+        return method_exists(Application::class, 'getTerminalDimensions');
     }
 }


### PR DESCRIPTION
This PR adds back support for Symfony 3 by making the integration tests compatible with both 3.x and 4.x.