### PR TITLE
Fix issue where it always spans a subprocess

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -135,7 +135,7 @@ trait Parallelization
                 'p',
                 InputOption::VALUE_OPTIONAL,
                 'The number of parallel processes to run',
-                1
+                null
             )
             ->addOption(
                 'child',
@@ -296,7 +296,7 @@ trait Parallelization
         $this->runBeforeFirstCommand($input, $output);
 
         $numberOfProcessesDefined = null !== $input->getOption('processes');
-        $numberOfProcesses = (int) $input->getOption('processes');
+        $numberOfProcesses = $numberOfProcessesDefined ? (int) $input->getOption('processes') : 1;
         $hasItem = (bool) $input->getArgument('item');
         $items = $hasItem ? [$input->getArgument('item')] : $this->fetchItems($input);
         $count = count($items);

--- a/tests/ParallelizationIntegrationTest.php
+++ b/tests/ParallelizationIntegrationTest.php
@@ -79,7 +79,7 @@ class ParallelizationIntegrationTest extends TestCase
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -95,7 +95,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB


### PR DESCRIPTION
I wanted to debug my command, but it is quite hard as currently it always starts a child process.
Investigating why that is I think #15 introduced a bug.

As far as I can see `$numberOfProcessesDefined = null !== $input->getOption('processes');` should ensure that if the parameter is not set, then the child process should not be spawned and instead the master process should run the code.

However the variable is always true, because the default value of `processes` is 1. To fix the issue the default value could be set to `null` and in `executeMasterProcess` it could check for null and set `numberOfProcesses` to `1` instead.

```
$numberOfProcessesDefined = null !== $input->getOption('processes');
$numberOfProcesses = $numberOfProcessesDefined ? (int) $input->getOption('processes') : 1;
```