### PR TITLE
Stream generation fix for Windows

### DIFF
--- a/src/ProcessLauncher.php
+++ b/src/ProcessLauncher.php
@@ -106,7 +106,7 @@ class ProcessLauncher
             }
 
             // Stream the data segment to the process' input stream
-            $currentInputStream->write($item."\n");
+            $currentInputStream->write($item.PHP_EOL);
 
             ++$numberOfStreamedItems;
         }


### PR DESCRIPTION
PHP_EOL instead of "\n" while creating stream (fix for windows with "\n\r")