### PR TITLE
Pass input options to child process

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -392,7 +392,7 @@ trait Parallelization
                         implode(' ', array_slice($input->getArguments(), 1)),
                         '--child',
                     ]),
-                    $this->serializeInputOptions($input, ['child', 'processes']))
+                    $this->serializeInputOptions($input, ['child', 'processes'])
                 )
             );
             $terminalWidth = (new Terminal())->getWidth();

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
+use function array_diff_key;
+use function array_fill_keys;
 use function array_filter;
+use function array_merge;
 use function array_slice;
 use function implode;
 use RuntimeException;
@@ -381,16 +384,16 @@ trait Parallelization
 
             $commandTemplate = implode(
                 ' ',
-                array_filter([
-                    self::detectPhpExecutable(),
-                    $consolePath,
-                    $this->getName(),
-                    implode(' ', array_slice($input->getArguments(), 1)),
-                    '--child',
-                    '--env='.$input->getOption('env'),
-                    $input->getOption('no-debug') ? '--no-debug' : '',
-                    implode(" ", $this->serializeInputOptions($input, ['child','env','no-debug', 'processes'])),
-                ])
+                array_merge(
+                    array_filter([
+                        self::detectPhpExecutable(),
+                        $consolePath,
+                        $this->getName(),
+                        implode(' ', array_slice($input->getArguments(), 1)),
+                        '--child',
+                    ]),
+                    $this->serializeInputOptions($input, ['child', 'processes']))
+                )
             );
             $terminalWidth = (new Terminal())->getWidth();
 
@@ -518,8 +521,7 @@ trait Parallelization
         }
     }
     
-/**
-     * @param InputInterface $input
+    /**
      * @param string[] $blackListParams
      * @return string[]
      */

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -389,7 +389,7 @@ trait Parallelization
                     '--child',
                     '--env='.$input->getOption('env'),
                     $input->getOption('no-debug') ? '--no-debug' : '',
-                    $this->serializeInputOptions($input, ['child','env','no-debug', 'processes']),
+                    implode(" ", $this->serializeInputOptions($input, ['child','env','no-debug', 'processes'])),
                 ])
             );
             $terminalWidth = (new Terminal())->getWidth();
@@ -518,19 +518,23 @@ trait Parallelization
         }
     }
     
-    /**
-     * @param string[] $blacklistParams
+/**
+     * @param InputInterface $input
+     * @param string[] $blackListParams
+     * @return string[]
      */
-    private function serializeInputOptions(InputInterface $input, array $blacklistParams) : string {
+    private function serializeInputOptions(InputInterface $input, array $blackListParams) : array {
         $options = array_diff_key(
             array_filter($input->getOptions()),
             array_fill_keys($blackListParams, '')
         );
 
-        $optionString = "";
+        $preparedOptionList = [];
         foreach ($options as $name => $value) {
             $definition = $this->getDefinition();
             $option = $definition->getOption($name);
+
+            $optionString  = "";
             if (!$option->acceptValue()) {
                 $optionString .= ' --' . $name;
             } elseif ($option->isArray()) {
@@ -540,7 +544,9 @@ trait Parallelization
             } else {
                 $optionString .= ' --'.$name.'='.$value;
             }
+
+            $preparedOptionList[] = $optionString;
         }
-        return $optionString;
+        return $preparedOptionList;
     }
 }

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -518,7 +518,10 @@ trait Parallelization
         }
     }
     
-        private function serializeInputOptions(InputInterface $input, array $blackListParams) : string {
+    /**
+     * @param string[] $blacklistParams
+     */
+    private function serializeInputOptions(InputInterface $input, array $blacklistParams) : string {
         $options = array_diff_key(
             array_filter($input->getOptions()),
             array_fill_keys($blackListParams, '')

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -389,6 +389,7 @@ trait Parallelization
                     '--child',
                     '--env='.$input->getOption('env'),
                     $input->getOption('no-debug') ? '--no-debug' : '',
+                    $this->serializeInputOptions($input, ['child','env','no-debug', 'processes']),
                 ])
             );
             $terminalWidth = (new Terminal())->getWidth();
@@ -515,5 +516,28 @@ trait Parallelization
                 $container->reset();
             }
         }
+    }
+    
+        private function serializeInputOptions(InputInterface $input, array $blackListParams) : string {
+        $options = array_diff_key(
+            array_filter($input->getOptions()),
+            array_fill_keys($blackListParams, '')
+        );
+
+        $optionString = "";
+        foreach ($options as $name => $value) {
+            $definition = $this->getDefinition();
+            $option = $definition->getOption($name);
+            if (!$option->acceptValue()) {
+                $optionString .= ' --' . $name;
+            } elseif ($option->isArray()) {
+                foreach ($value as $arrayValue) {
+                    $optionString .= ' --'.$name.'='.$arrayValue;
+                }
+            } else {
+                $optionString .= ' --'.$name.'='.$value;
+            }
+        }
+        return $optionString;
     }
 }


### PR DESCRIPTION
- Pass input options to child processes so that verbosity mode and other important parameters won't be lost.
- A blacklist still can be used to define (internal) options that shouldn't be passed.