### PR TITLE
Introduce ParallelizationInput °2

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -292,10 +292,8 @@ trait Parallelization
     ): void {
         $this->runBeforeFirstCommand($input, $output);
 
-        $numberOfProcessesDefined = $parallelizationInput->isNumberOfProcessesDefined();
         $numberOfProcesses = $parallelizationInput->getNumberOfProcesses();
         $segmentSize = $parallelizationInput->getSegmentSize();
-        $batchSize = $parallelizationInput->getBatchSize();
         $count = $parallelizationInput->getItemsCount();
         $rounds = $parallelizationInput->getRounds();
         $batches = $parallelizationInput->getBatches();
@@ -306,7 +304,7 @@ trait Parallelization
             $count,
             $this->getItemName($count),
             $segmentSize,
-            $batchSize,
+            $parallelizationInput->getBatchSize(),
             $rounds,
             1 === $rounds ? 'round' : 'rounds',
             $batches,
@@ -320,7 +318,9 @@ trait Parallelization
         $progressBar->setFormat('debug');
         $progressBar->start();
 
-        if ($count <= $segmentSize || (1 === $numberOfProcesses && !$numberOfProcessesDefined)) {
+        if ($count <= $segmentSize
+            || (1 === $numberOfProcesses && !$parallelizationInput->isNumberOfProcessesDefined())
+        ) {
             // Run in the master process
 
             $itemsChunks = array_chunk(

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -294,15 +294,15 @@ trait Parallelization
 
         $numberOfProcesses = $parallelizationInput->getNumberOfProcesses();
         $segmentSize = $parallelizationInput->getSegmentSize();
-        $count = $parallelizationInput->getItemsCount();
+        $numberOfItems = $parallelizationInput->getNumberOfItems();
         $rounds = $parallelizationInput->getRounds();
         $batches = $parallelizationInput->getBatches();
         $items = $parallelizationInput->getItems();
 
         $output->writeln(sprintf(
             'Processing %d %s in segments of %d, batches of %d, %d %s, %d %s in %d %s',
-            $count,
-            $this->getItemName($count),
+            $numberOfItems,
+            $this->getItemName($numberOfItems),
             $segmentSize,
             $parallelizationInput->getBatchSize(),
             $rounds,
@@ -314,11 +314,11 @@ trait Parallelization
         ));
         $output->writeln('');
 
-        $progressBar = new ProgressBar($output, $count);
+        $progressBar = new ProgressBar($output, $numberOfItems);
         $progressBar->setFormat('debug');
         $progressBar->start();
 
-        if ($count <= $segmentSize
+        if ($numberOfItems <= $segmentSize
             || (1 === $numberOfProcesses && !$parallelizationInput->isNumberOfProcessesDefined())
         ) {
             // Run in the master process
@@ -384,8 +384,8 @@ trait Parallelization
         $output->writeln('');
         $output->writeln(sprintf(
             'Processed %d %s.',
-            $count,
-            $this->getItemName($count)
+            $numberOfItems,
+            $this->getItemName($numberOfItems)
         ));
 
         $this->runAfterLastCommand($input, $output);

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -486,12 +486,14 @@ trait Parallelization
             }
         }
     }
-    
+
     /**
      * @param string[] $blackListParams
+     *
      * @return string[]
      */
-    private function serializeInputOptions(InputInterface $input, array $blackListParams) : array {
+    private function serializeInputOptions(InputInterface $input, array $blackListParams): array
+    {
         $options = array_diff_key(
             array_filter($input->getOptions()),
             array_fill_keys($blackListParams, '')
@@ -502,9 +504,9 @@ trait Parallelization
             $definition = $this->getDefinition();
             $option = $definition->getOption($name);
 
-            $optionString  = "";
+            $optionString = '';
             if (!$option->acceptValue()) {
-                $optionString .= ' --' . $name;
+                $optionString .= ' --'.$name;
             } elseif ($option->isArray()) {
                 foreach ($value as $arrayValue) {
                     $optionString .= ' --'.$name.'='.$arrayValue;
@@ -515,6 +517,7 @@ trait Parallelization
 
             $preparedOptionList[] = $optionString;
         }
+
         return $preparedOptionList;
     }
 }

--- a/src/ParallelizationInput.php
+++ b/src/ParallelizationInput.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use Closure;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Webmozart\Assert\Assert;
+use function array_values;
+use function ceil;
+use function count;
+use function gettype;
+use function is_int;
+use function is_numeric;
+use function sprintf;
+
+final class ParallelizationInput
+{
+    private const ITEM = 'item';
+    private const PROCESSES = 'processes';
+    private const CHILD = 'child';
+
+    private $numberOfProcessesDefined;
+    private $numberOfProcesses = 1;
+    private $items;
+    private $itemsCount;
+    private $segmentSize;
+    private $batchSize;
+    private $rounds;
+    private $batches;
+
+    /**
+     * Adds the command configuration specific to parallelization.
+     *
+     * Call this method in your configure() method.
+     */
+    public static function configureParallelization(Command $command): void
+    {
+        $command
+            ->addArgument(
+                self::ITEM,
+                InputArgument::OPTIONAL,
+                'The item to process'
+            )
+            ->addOption(
+                self::PROCESSES,
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'The number of parallel processes to run',
+                null
+            )
+            ->addOption(
+                self::CHILD,
+                null,
+                InputOption::VALUE_NONE,
+                'Set on child processes'
+            )
+        ;
+    }
+
+    /**
+     * @param Closure(InputInterface): string[] $itemsFetcher
+     */
+    public function __construct(
+        InputInterface $input,
+        Closure $itemsFetcher,
+        int $segmentSize,
+        int $batchSize
+    ) {
+        /** @var string|null $processes */
+        $processes = $input->getOption(self::PROCESSES);
+
+        $this->numberOfProcessesDefined = null !== $processes;
+
+        if ($this->numberOfProcessesDefined) {
+            Assert::numeric(
+                $processes,
+                sprintf(
+                    'Expected the number of process defined to be a valid numeric value. Got "%s"',
+                    $processes
+                )
+            );
+
+            $this->numberOfProcesses = (int) $processes;
+
+            Assert::same(
+                // We cast it again in string to make sure since it is more convenient to pass an
+                // int in the tests or when calling the command directly without passing by the CLI
+                (string) $processes,
+                (string) $this->numberOfProcesses,
+                sprintf(
+                    'Expected the number of process defined to be an integer. Got "%s"',
+                    $processes
+                )
+            );
+
+            Assert::greaterThan(
+                $this->numberOfProcesses,
+                0,
+                sprintf(
+                    'Requires at least one process. Got "%s"',
+                    $this->numberOfProcesses
+                )
+            );
+        }
+
+        /** @var string|null $item */
+        $item = $input->getArgument(self::ITEM);
+
+        $hasItem = null !== $item;
+
+        if ($hasItem && !is_int($item)) {
+            // Safeguard in case an invalid type is accidentally passed in tests when invoking the
+            // command directly
+            Assert::string($item);
+        }
+
+        $this->items = $hasItem
+            // We cast it again in case another value was passed when invoking the command
+            // directly in the tests
+            ? [(string) $item]
+            : self::retrieveItems($input, $itemsFetcher)
+        ;
+        $this->itemsCount = count($this->items);
+
+        $this->segmentSize = 1 === $this->numberOfProcesses && !$this->numberOfProcessesDefined ? $this->itemsCount : $segmentSize;
+        $this->batchSize = $batchSize;
+        $this->rounds = (int) (1 === $this->numberOfProcesses ? 1 : ceil($this->itemsCount / $segmentSize));
+        $this->batches = (int) (ceil($segmentSize / $batchSize) * $this->rounds);
+
+        if (!$hasItem && 1 !== $this->numberOfProcesses) {
+            // Shouldn't check this when only one item has been specified or
+            // when no child processes is used
+            Assert::greaterThanEq(
+                $segmentSize,
+                $batchSize,
+                sprintf(
+                    'The segment size ("%s") should always be greater or equal to the batch size ("%s")',
+                    $segmentSize,
+                    $batchSize
+                )
+            );
+        }
+    }
+
+    public function isNumberOfProcessesDefined(): bool
+    {
+        return $this->numberOfProcessesDefined;
+    }
+
+    public function getNumberOfProcesses(): int
+    {
+        return $this->numberOfProcesses;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function getItemsCount(): int
+    {
+        return $this->itemsCount;
+    }
+
+    public function getSegmentSize(): int
+    {
+        return $this->segmentSize;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
+    }
+
+    public function getRounds(): int
+    {
+        return $this->rounds;
+    }
+
+    public function getBatches(): int
+    {
+        return $this->batches;
+    }
+
+    /**
+     * @param Closure(InputInterface): string[] $itemsFetcher
+     *
+     * @return list<string>
+     */
+    private static function retrieveItems(InputInterface $input, Closure $itemsFetcher): array
+    {
+        $items = $itemsFetcher($input);
+
+        Assert::isArray(
+            $items,
+            sprintf(
+                'Expected the fetched items to be a list of strings. Got "%s"',
+                gettype($items)
+            )
+        );
+
+        foreach ($items as $index => $item) {
+            if (is_numeric($item)) {
+                $items[$index] = (string) $item;
+
+                continue;
+            }
+
+            Assert::string(
+                $item,
+                sprintf(
+                    'The items are potentially passed to the child processes via the STDIN. For this reason they are expected to be string values. Got "%s" for the item "%s"',
+                    gettype($item),
+                    $index
+                )
+            );
+        }
+
+        return array_values($items);
+    }
+}

--- a/src/ParallelizationInput.php
+++ b/src/ParallelizationInput.php
@@ -80,6 +80,34 @@ final class ParallelizationInput
         int $segmentSize,
         int $batchSize
     ) {
+        Assert::greaterThan(
+            $segmentSize,
+            0,
+            sprintf(
+                'Expected the segment size should allow at least 1 item. Got "%s"',
+                $segmentSize
+            )
+        );
+        Assert::greaterThan(
+            $batchSize,
+            0,
+            sprintf(
+                'Expected the batch size should allow at least 1 item. Got "%s"',
+                $batchSize
+            )
+        );
+        // We always check those (and not the calculated ones) since they come from the command
+        // configuration so an issue there hints on a misconfiguration which should be fixed.
+        Assert::greaterThanEq(
+            $segmentSize,
+            $batchSize,
+            sprintf(
+                'The segment size ("%s") should always be greater or equal to the batch size ("%s")',
+                $segmentSize,
+                $batchSize
+            )
+        );
+
         /** @var string|null $processes */
         $processes = $input->getOption(self::PROCESSES);
 
@@ -140,20 +168,6 @@ final class ParallelizationInput
         $this->batchSize = $batchSize;
         $this->rounds = (int) (1 === $this->numberOfProcesses ? 1 : ceil($this->itemsCount / $segmentSize));
         $this->batches = (int) (ceil($segmentSize / $batchSize) * $this->rounds);
-
-        if (!$hasItem && 1 !== $this->numberOfProcesses) {
-            // Shouldn't check this when only one item has been specified or
-            // when no child processes is used
-            Assert::greaterThanEq(
-                $segmentSize,
-                $batchSize,
-                sprintf(
-                    'The segment size ("%s") should always be greater or equal to the batch size ("%s")',
-                    $segmentSize,
-                    $batchSize
-                )
-            );
-        }
     }
 
     public function isNumberOfProcessesDefined(): bool

--- a/src/ParallelizationInput.php
+++ b/src/ParallelizationInput.php
@@ -29,14 +29,14 @@ use function sprintf;
 
 final class ParallelizationInput
 {
-    private const ITEM = 'item';
-    private const PROCESSES = 'processes';
-    private const CHILD = 'child';
+    private const ITEM_ARGUMENT = 'item';
+    private const PROCESSES_OPTION = 'processes';
+    private const CHILD_OPTION = 'child';
 
     private $numberOfProcessesDefined;
     private $numberOfProcesses = 1;
     private $items;
-    private $itemsCount;
+    private $numberOfItems;
     private $segmentSize;
     private $batchSize;
     private $rounds;
@@ -51,166 +51,24 @@ final class ParallelizationInput
     {
         $command
             ->addArgument(
-                self::ITEM,
+                self::ITEM_ARGUMENT,
                 InputArgument::OPTIONAL,
                 'The item to process'
             )
             ->addOption(
-                self::PROCESSES,
+                self::PROCESSES_OPTION,
                 'p',
                 InputOption::VALUE_OPTIONAL,
                 'The number of parallel processes to run',
                 null
             )
             ->addOption(
-                self::CHILD,
+                self::CHILD_OPTION,
                 null,
                 InputOption::VALUE_NONE,
                 'Set on child processes'
             )
         ;
-    }
-
-    /**
-     * @param Closure(InputInterface): string[] $itemsFetcher
-     */
-    public function __construct(
-        InputInterface $input,
-        Closure $itemsFetcher,
-        int $segmentSize,
-        int $batchSize
-    ) {
-        Assert::greaterThan(
-            $segmentSize,
-            0,
-            sprintf(
-                'Expected the segment size should allow at least 1 item. Got "%s"',
-                $segmentSize
-            )
-        );
-        Assert::greaterThan(
-            $batchSize,
-            0,
-            sprintf(
-                'Expected the batch size should allow at least 1 item. Got "%s"',
-                $batchSize
-            )
-        );
-        // We always check those (and not the calculated ones) since they come from the command
-        // configuration so an issue there hints on a misconfiguration which should be fixed.
-        Assert::greaterThanEq(
-            $segmentSize,
-            $batchSize,
-            sprintf(
-                'The segment size ("%s") should always be greater or equal to the batch size ("%s")',
-                $segmentSize,
-                $batchSize
-            )
-        );
-
-        /** @var string|null $processes */
-        $processes = $input->getOption(self::PROCESSES);
-
-        $this->numberOfProcessesDefined = null !== $processes;
-
-        if ($this->numberOfProcessesDefined) {
-            Assert::numeric(
-                $processes,
-                sprintf(
-                    'Expected the number of process defined to be a valid numeric value. Got "%s"',
-                    $processes
-                )
-            );
-
-            $this->numberOfProcesses = (int) $processes;
-
-            Assert::same(
-                // We cast it again in string to make sure since it is more convenient to pass an
-                // int in the tests or when calling the command directly without passing by the CLI
-                (string) $processes,
-                (string) $this->numberOfProcesses,
-                sprintf(
-                    'Expected the number of process defined to be an integer. Got "%s"',
-                    $processes
-                )
-            );
-
-            Assert::greaterThan(
-                $this->numberOfProcesses,
-                0,
-                sprintf(
-                    'Requires at least one process. Got "%s"',
-                    $this->numberOfProcesses
-                )
-            );
-        }
-
-        /** @var string|null $item */
-        $item = $input->getArgument(self::ITEM);
-
-        $hasItem = null !== $item;
-
-        if ($hasItem && !is_int($item)) {
-            // Safeguard in case an invalid type is accidentally passed in tests when invoking the
-            // command directly
-            Assert::string($item);
-        }
-
-        $this->items = $hasItem
-            // We cast it again in case another value was passed when invoking the command
-            // directly in the tests
-            ? [(string) $item]
-            : self::retrieveItems($input, $itemsFetcher)
-        ;
-        $this->itemsCount = count($this->items);
-
-        $this->segmentSize = 1 === $this->numberOfProcesses && !$this->numberOfProcessesDefined ? $this->itemsCount : $segmentSize;
-        $this->batchSize = $batchSize;
-        $this->rounds = (int) (1 === $this->numberOfProcesses ? 1 : ceil($this->itemsCount / $segmentSize));
-        $this->batches = (int) (ceil($segmentSize / $batchSize) * $this->rounds);
-    }
-
-    public function isNumberOfProcessesDefined(): bool
-    {
-        return $this->numberOfProcessesDefined;
-    }
-
-    public function getNumberOfProcesses(): int
-    {
-        return $this->numberOfProcesses;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getItems(): array
-    {
-        return $this->items;
-    }
-
-    public function getItemsCount(): int
-    {
-        return $this->itemsCount;
-    }
-
-    public function getSegmentSize(): int
-    {
-        return $this->segmentSize;
-    }
-
-    public function getBatchSize(): int
-    {
-        return $this->batchSize;
-    }
-
-    public function getRounds(): int
-    {
-        return $this->rounds;
-    }
-
-    public function getBatches(): int
-    {
-        return $this->batches;
     }
 
     /**
@@ -248,5 +106,150 @@ final class ParallelizationInput
         }
 
         return array_values($items);
+    }
+
+    /**
+     * @param Closure(InputInterface): string[] $itemsFetcher
+     */
+    public function __construct(
+        InputInterface $input,
+        Closure $itemsFetcher,
+        int $segmentSize,
+        int $batchSize
+    ) {
+        Assert::greaterThan(
+            $segmentSize,
+            0,
+            sprintf(
+                'Expected the segment size to be 1 or greater. Got "%s"',
+                $segmentSize
+            )
+        );
+        Assert::greaterThan(
+            $batchSize,
+            0,
+            sprintf(
+                'Expected the batch size to be 1 or greater. Got "%s"',
+                $batchSize
+            )
+        );
+        // We always check those (and not the calculated ones) since they come from the command
+        // configuration so an issue there hints on a misconfiguration which should be fixed.
+        Assert::greaterThanEq(
+            $segmentSize,
+            $batchSize,
+            sprintf(
+                'Expected the segment size ("%s") to be greater or equal to the batch size ("%s")',
+                $segmentSize,
+                $batchSize
+            )
+        );
+
+        /** @var string|null $processes */
+        $processes = $input->getOption(self::PROCESSES_OPTION);
+
+        $this->numberOfProcessesDefined = null !== $processes;
+
+        if ($this->numberOfProcessesDefined) {
+            Assert::numeric(
+                $processes,
+                sprintf(
+                    'Expected the number of process defined to be a valid numeric value. Got "%s"',
+                    $processes
+                )
+            );
+
+            $this->numberOfProcesses = (int) $processes;
+
+            Assert::same(
+                // We cast it again in string to make sure since it is more convenient to pass an
+                // int in the tests or when calling the command directly without passing by the CLI
+                (string) $processes,
+                (string) $this->numberOfProcesses,
+                sprintf(
+                    'Expected the number of process defined to be an integer. Got "%s"',
+                    $processes
+                )
+            );
+
+            Assert::greaterThan(
+                $this->numberOfProcesses,
+                0,
+                sprintf(
+                    'Requires at least one process. Got "%s"',
+                    $this->numberOfProcesses
+                )
+            );
+        }
+
+        /** @var string|null $item */
+        $item = $input->getArgument(self::ITEM_ARGUMENT);
+
+        $hasItem = null !== $item;
+
+        if ($hasItem && !is_int($item)) {
+            // Safeguard in case an invalid type is accidentally passed in tests when invoking the
+            // command directly
+            Assert::string($item);
+        }
+
+        $this->items = $hasItem
+            // We cast it again in case another value was passed when invoking the command
+            // directly in the tests
+            ? [(string) $item]
+            : self::retrieveItems($input, $itemsFetcher)
+        ;
+        $this->numberOfItems = count($this->items);
+
+        $this->segmentSize = 1 === $this->numberOfProcesses && !$this->numberOfProcessesDefined
+            ? $this->numberOfItems
+            : $segmentSize
+        ;
+        $this->batchSize = $batchSize;
+        $this->rounds = (int) (1 === $this->numberOfProcesses ? 1 : ceil($this->numberOfItems / $segmentSize));
+        $this->batches = (int) (ceil($segmentSize / $batchSize) * $this->rounds);
+    }
+
+    public function isNumberOfProcessesDefined(): bool
+    {
+        return $this->numberOfProcessesDefined;
+    }
+
+    public function getNumberOfProcesses(): int
+    {
+        return $this->numberOfProcesses;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function getNumberOfItems(): int
+    {
+        return $this->numberOfItems;
+    }
+
+    public function getSegmentSize(): int
+    {
+        return $this->segmentSize;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
+    }
+
+    public function getRounds(): int
+    {
+        return $this->rounds;
+    }
+
+    public function getBatches(): int
+    {
+        return $this->batches;
     }
 }

--- a/tests/ParallelizationInputTest.php
+++ b/tests/ParallelizationInputTest.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
-use Closure;
 use InvalidArgumentException;
-use LogicException;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
-use function func_get_args;
 
 /**
  * @covers \Webmozarts\Console\Parallelization\ParallelizationInput
@@ -50,44 +47,25 @@ final class ParallelizationInputTest extends TestCase
 
     /**
      * @dataProvider inputProvider
-     *
-     * @param Closure(InputInterface): string[] $itemsFetcher
-     * @param string[]                          $expectedItems
      */
     public function test_it_can_be_instantiated(
         InputInterface $input,
-        Closure $itemsFetcher,
-        int $segmentSize,
-        int $batchSize,
         bool $expectedIsNumberOfProcessesDefined,
         int $expectedNumberOfProcesses,
-        array $expectedItems,
-        int $expectedNumberOfItems,
-        int $expectedSegmentSize,
-        int $expectedBatchSize,
-        int $expectedRounds,
-        int $expectedBatches
+        ?string $expectedItem,
+        bool $expectedIsChildProcess
     ): void {
         self::bindInput($input);
 
-        $parallelizationInput = new ParallelizationInput(
-            $input,
-            $itemsFetcher,
-            $segmentSize,
-            $batchSize
-        );
+        $parallelizationInput = new ParallelizationInput($input);
 
         $this->assertSame(
             $expectedIsNumberOfProcessesDefined,
             $parallelizationInput->isNumberOfProcessesDefined()
         );
         $this->assertSame($expectedNumberOfProcesses, $parallelizationInput->getNumberOfProcesses());
-        $this->assertSame($expectedItems, $parallelizationInput->getItems());
-        $this->assertSame($expectedNumberOfItems, $parallelizationInput->getNumberOfItems());
-        $this->assertSame($expectedSegmentSize, $parallelizationInput->getSegmentSize());
-        $this->assertSame($expectedBatchSize, $parallelizationInput->getBatchSize());
-        $this->assertSame($expectedRounds, $parallelizationInput->getRounds());
-        $this->assertSame($expectedBatches, $parallelizationInput->getBatches());
+        $this->assertSame($expectedItem, $parallelizationInput->getItem());
+        $this->assertSame($expectedIsChildProcess, $parallelizationInput->isChildProcess());
     }
 
     /**
@@ -102,353 +80,74 @@ final class ParallelizationInputTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedErrorMessage);
 
-        new ParallelizationInput(
-            $input,
-            self::createFakeClosure(),
-            1,
-            1
-        );
-    }
-
-    /**
-     * @dataProvider invalidItemsFetcherProvider
-     */
-    public function test_it_expects_the_items_fetcher_to_return_serialized_items(
-        Closure $itemsFetcher,
-        string $expectedErrorMessage
-    ): void {
-        $input = new StringInput('');
-
-        self::bindInput($input);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedErrorMessage);
-
-        new ParallelizationInput(
-            $input,
-            $itemsFetcher,
-            1,
-            1
-        );
-    }
-
-    /**
-     * @dataProvider itemsFetcherProvider
-     *
-     * @param list<string> $expectedItems
-     */
-    public function test_it_normalizes_the_fetched_items(
-        Closure $itemsFetcher,
-        array $expectedItems
-    ): void {
-        $input = new StringInput('');
-
-        self::bindInput($input);
-
-        $parallelizationInput = new ParallelizationInput(
-            $input,
-            $itemsFetcher,
-            1,
-            1
-        );
-
-        $this->assertSame($expectedItems, $parallelizationInput->getItems());
-    }
-
-    /**
-     * @dataProvider invalidSegmentAndBatchSizeProvider
-     */
-    public function test_it_cannot_accept_invalid_segment_or_batch_sizes(
-        int $segmentSize,
-        int $batchSize,
-        string $errorMessage
-    ): void {
-        $input = new StringInput('');
-
-        self::bindInput($input);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($errorMessage);
-
-        new ParallelizationInput(
-            $input,
-            $this->createFakeClosure(),
-            $segmentSize,
-            $batchSize
-        );
+        new ParallelizationInput($input);
     }
 
     public static function inputProvider(): iterable
     {
-        yield 'empty input' => self::createInputArgs(
+        yield 'empty input' => [
             new StringInput(''),
-            static function (): array {
-                return ['item0', 'item1'];
-            },
-            10,
-            5,
             false,
             1,
-            ['item0', 'item1'],
-            2,
-            2,
-            5,
-            1,
-            2
-        );
+            null,
+            false,
+        ];
 
-        yield 'number of process defined: 1' => self::createInputArgs(
+        yield 'number of process defined: 1' => [
             new StringInput('--processes=1'),
-            static function (): array {
-                return ['item0', 'item1'];
-            },
-            10,
-            5,
             true,
             1,
-            ['item0', 'item1'],
-            2,
-            10,
-            5,
-            1,
-            2
-        );
+            null,
+            false,
+        ];
 
-        yield 'number of process defined: 4' => self::createInputArgs(
+        yield 'number of process defined: 4' => [
             new StringInput('--processes=4'),
-            static function (): array {
-                return ['item0', 'item1'];
-            },
-            10,
-            5,
             true,
             4,
-            ['item0', 'item1'],
-            2,
-            10,
-            5,
-            1,
-            2
-        );
+            null,
+            false,
+        ];
 
-        yield 'one item passed – items fetched not called' => self::createInputArgs(
+        yield 'item passed' => [
             new StringInput('item15'),
-            self::createFakeClosure(),
-            10,
-            5,
             false,
             1,
-            ['item15'],
-            1,
-            1,
-            5,
-            1,
-            2
-        );
-
-        yield 'empty input with string items' => self::createInputArgs(
-            new StringInput(''),
-            static function (): array {
-                return ['item0', 'item1'];
-            },
-            10,
-            5,
+            'item15',
             false,
-            1,
-            ['item0', 'item1'],
-            2,
-            2,
-            5,
-            1,
-            2
-        );
-
-        yield 'empty input with integer items – items are "serialized"' => self::createInputArgs(
-            new StringInput(''),
-            static function (): array {
-                return [1000, 1001];
-            },
-            10,
-            5,
-            false,
-            1,
-            ['1000', '1001'],
-            2,
-            2,
-            5,
-            1,
-            2
-        );
-
-        yield 'segment size with no process defined: takes the item count' => self::createInputArgs(
-            new StringInput(''),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3'];
-            },
-            1,
-            1,
-            false,
-            1,
-            ['item0', 'item1', 'item2', 'item3'],
-            4,
-            4,
-            1,
-            1,
-            1
-        );
-
-        yield 'segment size with no process defined: takes the given segment size' => self::createInputArgs(
-            new StringInput('--processes=7'),
-            static function (): array {
-                return ['item0', 'item1'];
-            },
-            7,
-            5,
-            true,
-            7,
-            ['item0', 'item1'],
-            2,
-            7,
-            5,
-            1,
-            2
-        );
-
-        yield 'number of rounds: 1 process = 1 round' => self::createInputArgs(
-            new StringInput(''),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3'];
-            },
-            1,
-            1,
-            false,
-            1,
-            ['item0', 'item1', 'item2', 'item3'],
-            4,
-            4,
-            1,
-            1,
-            1
-        );
-
-        yield 'number of rounds: 2 process just enough for the number of items' => self::createInputArgs(
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3'];
-            },
-            2,
-            1,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3'],
-            4,
-            2,
-            1,
-            2,
-            4
-        );
-
-        yield 'number of rounds: 2 process - half' => self::createInputArgs(
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3', 'item4'];
-            },
-            2,
-            1,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3', 'item4'],
-            5,
-            2,
-            1,
-            3,
-            6
-        );
-
-        yield 'number of rounds: 2 process - under' => [
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3', 'item4'];
-            },
-            4,
-            1,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3', 'item4'],
-            5,
-            4,
-            1,
-            2,
-            8,
         ];
 
-        yield 'number of rounds: 2 process - up' => [
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'];
-            },
-            4,
+        yield 'integer item passed' => [
+            new ArrayInput(['item' => 10]),
+            false,
             1,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'],
-            8,
-            4,
-            1,
-            2,
-            8,
+            '10',
+            false,
         ];
 
-        yield 'number of batches: 2 process - half' => self::createInputArgs(
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3', 'item4'];
-            },
-            3,
-            2,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3', 'item4'],
-            5,
-            3,
-            2,
-            2,
-            4
-        );
-
-        yield 'number of batches: 2 process - under' => self::createInputArgs(
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3', 'item4'];
-            },
-            5,
-            4,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3', 'item4'],
-            5,
-            5,
-            4,
+        yield 'float item passed' => [
+            new ArrayInput(['item' => -.5]),
+            false,
             1,
-            2
-        );
+            '-0.5',
+            false,
+        ];
 
-        yield 'number of batches: 2 process - up' => self::createInputArgs(
-            new StringInput('--processes=2'),
-            static function (): array {
-                return ['item0', 'item1', 'item2', 'item3', 'item4'];
-            },
-            7,
-            3,
-            true,
-            2,
-            ['item0', 'item1', 'item2', 'item3', 'item4'],
-            5,
-            7,
-            3,
+        yield 'child option' => [
+            new StringInput('--child'),
+            false,
             1,
-            3
-        );
+            null,
+            true,
+        ];
+
+        yield 'nominal' => [
+            new StringInput('item15 --child --processes 15'),
+            true,
+            15,
+            'item15',
+            true,
+        ];
     }
 
     public static function invalidNumberOfProcessesProvider(): iterable
@@ -462,118 +161,6 @@ final class ParallelizationInputTest extends TestCase
             new StringInput('--processes 1.5'),
             'Expected the number of process defined to be an integer. Got "1.5"',
         ];
-
-        yield 'non >=1 value' => [
-            new StringInput('--processes 0'),
-            'Requires at least one process. Got "0"',
-        ];
-    }
-
-    public static function invalidItemsFetcherProvider(): iterable
-    {
-        yield 'non array' => [
-            static function () {
-                return new stdClass();
-            },
-            'Expected the fetched items to be a list of strings. Got "object"',
-        ];
-
-        yield 'array with object item' => [
-            static function () {
-                return [new stdClass()];
-            },
-            'The items are potentially passed to the child processes via the STDIN. For this reason they are expected to be string values. Got "object" for the item "0"',
-        ];
-
-        yield 'array with object item with index' => [
-            static function () {
-                return ['foo' => new stdClass()];
-            },
-            'The items are potentially passed to the child processes via the STDIN. For this reason they are expected to be string values. Got "object" for the item "foo"',
-        ];
-    }
-
-    public static function itemsFetcherProvider(): iterable
-    {
-        yield 'empty array' => [
-            static function () {
-                return [];
-            },
-            [],
-        ];
-
-        yield 'string values' => [
-            static function () {
-                return ['item0', 'item1'];
-            },
-            ['item0', 'item1'],
-        ];
-
-        yield 'string values with keys' => [
-            static function () {
-                return ['foo' => 'item0', 'bar' => 'item1'];
-            },
-            ['item0', 'item1'],
-        ];
-
-        yield 'numeric values' => [
-            static function () {
-                return [1.5, 5];
-            },
-            ['1.5', '5'],
-        ];
-
-        yield 'numeric values with keys' => [
-            static function () {
-                return ['foo' => 1.5, 'bar' => 5];
-            },
-            ['1.5', '5'],
-        ];
-    }
-
-    public static function invalidSegmentAndBatchSizeProvider(): iterable
-    {
-        yield 'segment size smaller than batch size' => [
-            10,
-            50,
-            'The segment size ("10") should always be greater or equal to the batch size ("50")',
-        ];
-
-        yield 'invalid segment size' => [
-            0,
-            0,
-            'Expected the segment size should allow at least 1 item. Got "0"',
-        ];
-
-        yield 'invalid batch size' => [
-            10,
-            0,
-            'Expected the batch size should allow at least 1 item. Got "0"',
-        ];
-    }
-
-    private static function createFakeClosure(): Closure
-    {
-        return static function () {
-            throw new LogicException('Did not expect to be called');
-        };
-    }
-
-    private static function createInputArgs(
-        InputInterface $input,
-        Closure $itemsFetcher,
-        int $segmentSize,
-        int $batchSize,
-        bool $expectedIsNumberOfProcessesDefined,
-        int $expectedNumberOfProcesses,
-        array $expectedItems,
-        int $expectedNumberOfItemsCount,
-        int $expectedSegmentSize,
-        int $expectedBatchSize,
-        int $expectedRounds,
-        int $expectedBatches
-    ): array {
-        return func_get_args();
     }
 
     private static function bindInput(InputInterface $input): void

--- a/tests/ParallelizationInputTest.php
+++ b/tests/ParallelizationInputTest.php
@@ -1,0 +1,548 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use Closure;
+use InvalidArgumentException;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use function func_get_args;
+
+/**
+ * @covers \Webmozarts\Console\Parallelization\ParallelizationInput
+ */
+final class ParallelizationInputTest extends TestCase
+{
+    public function test_it_can_configure_a_command(): void
+    {
+        $command = new Command();
+
+        $initialDefinition = $command->getDefinition();
+
+        // Sanity check
+        $this->assertFalse($initialDefinition->hasArgument('item'));
+        $this->assertFalse($initialDefinition->hasOption('processes'));
+        $this->assertFalse($initialDefinition->hasOption('child'));
+
+        ParallelizationInput::configureParallelization($command);
+
+        $configuredDefinition = $command->getDefinition();
+
+        $this->assertTrue($configuredDefinition->hasArgument('item'));
+        $this->assertTrue($configuredDefinition->hasOption('processes'));
+        $this->assertTrue($configuredDefinition->hasOption('child'));
+    }
+
+    /**
+     * @dataProvider inputProvider
+     *
+     * @param Closure(InputInterface): string[] $itemsFetcher
+     * @param string[]                          $expectedItems
+     */
+    public function test_it_can_be_instantiated(
+        InputInterface $input,
+        Closure $itemsFetcher,
+        int $segmentSize,
+        int $batchSize,
+        bool $expectedIsNumberOfProcessesDefined,
+        int $expectedNumberOfProcesses,
+        array $expectedItems,
+        int $expectedItemsCount,
+        int $expectedSegmentSize,
+        int $expectedBatchSize,
+        int $expectedRounds,
+        int $expectedBatches
+    ): void {
+        $command = new Command();
+
+        ParallelizationInput::configureParallelization($command);
+
+        $input->bind($command->getDefinition());
+
+        $parallelizationInput = new ParallelizationInput(
+            $input,
+            $itemsFetcher,
+            $segmentSize,
+            $batchSize
+        );
+
+        $this->assertSame(
+            $expectedIsNumberOfProcessesDefined,
+            $parallelizationInput->isNumberOfProcessesDefined()
+        );
+        $this->assertSame($expectedNumberOfProcesses, $parallelizationInput->getNumberOfProcesses());
+        $this->assertSame($expectedItems, $parallelizationInput->getItems());
+        $this->assertSame($expectedItemsCount, $parallelizationInput->getItemsCount());
+        $this->assertSame($expectedSegmentSize, $parallelizationInput->getSegmentSize());
+        $this->assertSame($expectedBatchSize, $parallelizationInput->getBatchSize());
+        $this->assertSame($expectedRounds, $parallelizationInput->getRounds());
+        $this->assertSame($expectedBatches, $parallelizationInput->getBatches());
+    }
+
+    /**
+     * @dataProvider invalidNumberOfProcessesProvider
+     */
+    public function test_it_cannot_pass_an_invalid_number_of_processes(
+        InputInterface $input,
+        string $expectedErrorMessage
+    ): void {
+        $command = new Command();
+
+        ParallelizationInput::configureParallelization($command);
+
+        $input->bind($command->getDefinition());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedErrorMessage);
+
+        new ParallelizationInput(
+            $input,
+            self::createFakeClosure(),
+            1,
+            1
+        );
+    }
+
+    /**
+     * @dataProvider invalidItemsFetcherProvider
+     */
+    public function test_it_expects_the_items_fetcher_to_return_serialized_items(
+        Closure $itemsFetcher,
+        string $expectedErrorMessage
+    ): void {
+        $command = new Command();
+
+        ParallelizationInput::configureParallelization($command);
+
+        $input = new StringInput('');
+        $input->bind($command->getDefinition());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedErrorMessage);
+
+        new ParallelizationInput(
+            $input,
+            $itemsFetcher,
+            1,
+            1
+        );
+    }
+
+    /**
+     * @dataProvider itemsFetcherProvider
+     *
+     * @param list<string> $expectedItems
+     */
+    public function test_it_normalizes_the_fetched_items(
+        Closure $itemsFetcher,
+        array $expectedItems
+    ): void {
+        $command = new Command();
+
+        ParallelizationInput::configureParallelization($command);
+
+        $input = new StringInput('');
+        $input->bind($command->getDefinition());
+
+        $parallelizationInput = new ParallelizationInput(
+            $input,
+            $itemsFetcher,
+            1,
+            1
+        );
+
+        $this->assertSame($expectedItems, $parallelizationInput->getItems());
+    }
+
+    public static function inputProvider(): iterable
+    {
+        yield 'empty input' => self::createInputArgs(
+            new StringInput(''),
+            static function (): array {
+                return ['item0', 'item1'];
+            },
+            10,
+            5,
+            false,
+            1,
+            ['item0', 'item1'],
+            2,
+            2,
+            5,
+            1,
+            2
+        );
+
+        yield 'number of process defined: 1' => self::createInputArgs(
+            new StringInput('--processes=1'),
+            static function (): array {
+                return ['item0', 'item1'];
+            },
+            10,
+            5,
+            true,
+            1,
+            ['item0', 'item1'],
+            2,
+            10,
+            5,
+            1,
+            2
+        );
+
+        yield 'number of process defined: 4' => self::createInputArgs(
+            new StringInput('--processes=4'),
+            static function (): array {
+                return ['item0', 'item1'];
+            },
+            10,
+            5,
+            true,
+            4,
+            ['item0', 'item1'],
+            2,
+            10,
+            5,
+            1,
+            2
+        );
+
+        yield 'one item passed – items fetched not called' => self::createInputArgs(
+            new StringInput('item15'),
+            self::createFakeClosure(),
+            10,
+            5,
+            false,
+            1,
+            ['item15'],
+            1,
+            1,
+            5,
+            1,
+            2
+        );
+
+        yield 'empty input with string items' => self::createInputArgs(
+            new StringInput(''),
+            static function (): array {
+                return ['item0', 'item1'];
+            },
+            10,
+            5,
+            false,
+            1,
+            ['item0', 'item1'],
+            2,
+            2,
+            5,
+            1,
+            2
+        );
+
+        yield 'empty input with integer items – items are "serialized"' => self::createInputArgs(
+            new StringInput(''),
+            static function (): array {
+                return [1000, 1001];
+            },
+            10,
+            5,
+            false,
+            1,
+            ['1000', '1001'],
+            2,
+            2,
+            5,
+            1,
+            2
+        );
+
+        yield 'segment size with no process defined: takes the item count' => self::createInputArgs(
+            new StringInput(''),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3'];
+            },
+            1,
+            5,
+            false,
+            1,
+            ['item0', 'item1', 'item2', 'item3'],
+            4,
+            4,
+            5,
+            1,
+            1
+        );
+
+        yield 'segment size with no process defined: takes the given segment size' => self::createInputArgs(
+            new StringInput('--processes=7'),
+            static function (): array {
+                return ['item0', 'item1'];
+            },
+            7,
+            5,
+            true,
+            7,
+            ['item0', 'item1'],
+            2,
+            7,
+            5,
+            1,
+            2
+        );
+
+        yield 'number of rounds: 1 process = 1 round' => self::createInputArgs(
+            new StringInput(''),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3'];
+            },
+            1,
+            5,
+            false,
+            1,
+            ['item0', 'item1', 'item2', 'item3'],
+            4,
+            4,
+            5,
+            1,
+            1
+        );
+
+        yield 'number of rounds: 2 process just enough for the number of items' => self::createInputArgs(
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3'];
+            },
+            2,
+            1,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3'],
+            4,
+            2,
+            1,
+            2,
+            4
+        );
+
+        yield 'number of rounds: 2 process - half' => self::createInputArgs(
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3', 'item4'];
+            },
+            2,
+            1,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3', 'item4'],
+            5,
+            2,
+            1,
+            3,
+            6
+        );
+
+        yield 'number of rounds: 2 process - under' => [
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3', 'item4'];
+            },
+            4,
+            1,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3', 'item4'],
+            5,
+            4,
+            1,
+            2,
+            8,
+        ];
+
+        yield 'number of rounds: 2 process - up' => [
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'];
+            },
+            4,
+            1,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'],
+            8,
+            4,
+            1,
+            2,
+            8,
+        ];
+
+        yield 'number of batches: 2 process - half' => self::createInputArgs(
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3', 'item4'];
+            },
+            3,
+            2,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3', 'item4'],
+            5,
+            3,
+            2,
+            2,
+            4
+        );
+
+        yield 'number of batches: 2 process - under' => self::createInputArgs(
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3', 'item4'];
+            },
+            5,
+            4,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3', 'item4'],
+            5,
+            5,
+            4,
+            1,
+            2
+        );
+
+        yield 'number of batches: 2 process - up' => self::createInputArgs(
+            new StringInput('--processes=2'),
+            static function (): array {
+                return ['item0', 'item1', 'item2', 'item3', 'item4'];
+            },
+            7,
+            3,
+            true,
+            2,
+            ['item0', 'item1', 'item2', 'item3', 'item4'],
+            5,
+            7,
+            3,
+            1,
+            3
+        );
+    }
+
+    public static function invalidNumberOfProcessesProvider(): iterable
+    {
+        yield 'non numeric value' => [
+            new StringInput('--processes foo'),
+            'Expected the number of process defined to be a valid numeric value. Got "foo"',
+        ];
+
+        yield 'non integer value' => [
+            new StringInput('--processes 1.5'),
+            'Expected the number of process defined to be an integer. Got "1.5"',
+        ];
+
+        yield 'non >=1 value' => [
+            new StringInput('--processes 0'),
+            'Requires at least one process. Got "0"',
+        ];
+    }
+
+    public static function invalidItemsFetcherProvider(): iterable
+    {
+        yield 'non array' => [
+            static function () {
+                return new stdClass();
+            },
+            'Expected the fetched items to be a list of strings. Got "object"',
+        ];
+
+        yield 'array with object item' => [
+            static function () {
+                return [new stdClass()];
+            },
+            'The items are potentially passed to the child processes via the STDIN. For this reason they are expected to be string values. Got "object" for the item "0"',
+        ];
+
+        yield 'array with object item with index' => [
+            static function () {
+                return ['foo' => new stdClass()];
+            },
+            'The items are potentially passed to the child processes via the STDIN. For this reason they are expected to be string values. Got "object" for the item "foo"',
+        ];
+    }
+
+    public static function itemsFetcherProvider(): iterable
+    {
+        yield 'empty array' => [
+            static function () {
+                return [];
+            },
+            [],
+        ];
+
+        yield 'string values' => [
+            static function () {
+                return ['item0', 'item1'];
+            },
+            ['item0', 'item1'],
+        ];
+
+        yield 'string values with keys' => [
+            static function () {
+                return ['foo' => 'item0', 'bar' => 'item1'];
+            },
+            ['item0', 'item1'],
+        ];
+
+        yield 'numeric values' => [
+            static function () {
+                return [1.5, 5];
+            },
+            ['1.5', '5'],
+        ];
+
+        yield 'numeric values with keys' => [
+            static function () {
+                return ['foo' => 1.5, 'bar' => 5];
+            },
+            ['1.5', '5'],
+        ];
+    }
+
+    private static function createFakeClosure(): Closure
+    {
+        return static function () {
+            throw new LogicException('Did not expect to be called');
+        };
+    }
+
+    private static function createInputArgs(
+        InputInterface $input,
+        Closure $itemsFetcher,
+        int $segmentSize,
+        int $batchSize,
+        bool $expectedIsNumberOfProcessesDefined,
+        int $expectedNumberOfProcesses,
+        array $expectedItems,
+        int $expectedItemsCount,
+        int $expectedSegmentSize,
+        int $expectedBatchSize,
+        int $expectedRounds,
+        int $expectedBatches
+    ): array {
+        return func_get_args();
+    }
+}

--- a/tests/ParallelizationInputTest.php
+++ b/tests/ParallelizationInputTest.php
@@ -62,7 +62,7 @@ final class ParallelizationInputTest extends TestCase
         bool $expectedIsNumberOfProcessesDefined,
         int $expectedNumberOfProcesses,
         array $expectedItems,
-        int $expectedItemsCount,
+        int $expectedNumberOfItems,
         int $expectedSegmentSize,
         int $expectedBatchSize,
         int $expectedRounds,
@@ -83,7 +83,7 @@ final class ParallelizationInputTest extends TestCase
         );
         $this->assertSame($expectedNumberOfProcesses, $parallelizationInput->getNumberOfProcesses());
         $this->assertSame($expectedItems, $parallelizationInput->getItems());
-        $this->assertSame($expectedItemsCount, $parallelizationInput->getItemsCount());
+        $this->assertSame($expectedNumberOfItems, $parallelizationInput->getNumberOfItems());
         $this->assertSame($expectedSegmentSize, $parallelizationInput->getSegmentSize());
         $this->assertSame($expectedBatchSize, $parallelizationInput->getBatchSize());
         $this->assertSame($expectedRounds, $parallelizationInput->getRounds());
@@ -567,7 +567,7 @@ final class ParallelizationInputTest extends TestCase
         bool $expectedIsNumberOfProcessesDefined,
         int $expectedNumberOfProcesses,
         array $expectedItems,
-        int $expectedItemsCount,
+        int $expectedNumberOfItemsCount,
         int $expectedSegmentSize,
         int $expectedBatchSize,
         int $expectedRounds,

--- a/tests/ParallelizationInputTest.php
+++ b/tests/ParallelizationInputTest.php
@@ -155,6 +155,29 @@ final class ParallelizationInputTest extends TestCase
         $this->assertSame($expectedItems, $parallelizationInput->getItems());
     }
 
+    /**
+     * @dataProvider invalidSegmentAndBatchSizeProvider
+     */
+    public function test_it_cannot_accept_invalid_segment_or_batch_sizes(
+        int $segmentSize,
+        int $batchSize,
+        string $errorMessage
+    ): void {
+        $input = new StringInput('');
+
+        self::bindInput($input);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($errorMessage);
+
+        new ParallelizationInput(
+            $input,
+            $this->createFakeClosure(),
+            $segmentSize,
+            $batchSize
+        );
+    }
+
     public static function inputProvider(): iterable
     {
         yield 'empty input' => self::createInputArgs(
@@ -263,13 +286,13 @@ final class ParallelizationInputTest extends TestCase
                 return ['item0', 'item1', 'item2', 'item3'];
             },
             1,
-            5,
+            1,
             false,
             1,
             ['item0', 'item1', 'item2', 'item3'],
             4,
             4,
-            5,
+            1,
             1,
             1
         );
@@ -297,13 +320,13 @@ final class ParallelizationInputTest extends TestCase
                 return ['item0', 'item1', 'item2', 'item3'];
             },
             1,
-            5,
+            1,
             false,
             1,
             ['item0', 'item1', 'item2', 'item3'],
             4,
             4,
-            5,
+            1,
             1,
             1
         );
@@ -505,6 +528,27 @@ final class ParallelizationInputTest extends TestCase
                 return ['foo' => 1.5, 'bar' => 5];
             },
             ['1.5', '5'],
+        ];
+    }
+
+    public static function invalidSegmentAndBatchSizeProvider(): iterable
+    {
+        yield 'segment size smaller than batch size' => [
+            10,
+            50,
+            'The segment size ("10") should always be greater or equal to the batch size ("50")',
+        ];
+
+        yield 'invalid segment size' => [
+            0,
+            0,
+            'Expected the segment size should allow at least 1 item. Got "0"',
+        ];
+
+        yield 'invalid batch size' => [
+            10,
+            0,
+            'Expected the batch size should allow at least 1 item. Got "0"',
         ];
     }
 

--- a/tests/ParallelizationInputTest.php
+++ b/tests/ParallelizationInputTest.php
@@ -68,11 +68,7 @@ final class ParallelizationInputTest extends TestCase
         int $expectedRounds,
         int $expectedBatches
     ): void {
-        $command = new Command();
-
-        ParallelizationInput::configureParallelization($command);
-
-        $input->bind($command->getDefinition());
+        self::bindInput($input);
 
         $parallelizationInput = new ParallelizationInput(
             $input,
@@ -101,11 +97,7 @@ final class ParallelizationInputTest extends TestCase
         InputInterface $input,
         string $expectedErrorMessage
     ): void {
-        $command = new Command();
-
-        ParallelizationInput::configureParallelization($command);
-
-        $input->bind($command->getDefinition());
+        self::bindInput($input);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedErrorMessage);
@@ -125,12 +117,9 @@ final class ParallelizationInputTest extends TestCase
         Closure $itemsFetcher,
         string $expectedErrorMessage
     ): void {
-        $command = new Command();
-
-        ParallelizationInput::configureParallelization($command);
-
         $input = new StringInput('');
-        $input->bind($command->getDefinition());
+
+        self::bindInput($input);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedErrorMessage);
@@ -152,12 +141,9 @@ final class ParallelizationInputTest extends TestCase
         Closure $itemsFetcher,
         array $expectedItems
     ): void {
-        $command = new Command();
-
-        ParallelizationInput::configureParallelization($command);
-
         $input = new StringInput('');
-        $input->bind($command->getDefinition());
+
+        self::bindInput($input);
 
         $parallelizationInput = new ParallelizationInput(
             $input,
@@ -544,5 +530,14 @@ final class ParallelizationInputTest extends TestCase
         int $expectedBatches
     ): array {
         return func_get_args();
+    }
+
+    private static function bindInput(InputInterface $input): void
+    {
+        $command = new Command();
+
+        ParallelizationInput::configureParallelization($command);
+
+        $input->bind($command->getDefinition());
     }
 }

--- a/tests/ParallelizationIntegrationTest.php
+++ b/tests/ParallelizationIntegrationTest.php
@@ -78,7 +78,7 @@ class ParallelizationIntegrationTest extends TestCase
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batch in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -94,7 +94,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batch in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -124,7 +124,7 @@ EOF
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -140,7 +140,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -170,7 +170,7 @@ EOF
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 processes
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 2 processes
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -186,7 +186,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 processes
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 2 processes
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -216,7 +216,7 @@ EOF
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -232,7 +232,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB

--- a/tests/ParallelizationIntegrationTest.php
+++ b/tests/ParallelizationIntegrationTest.php
@@ -78,7 +78,7 @@ class ParallelizationIntegrationTest extends TestCase
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batch in 1 process
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -94,7 +94,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batch in 1 process
+Processing 2 movies in segments of 2, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -124,7 +124,7 @@ EOF
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -140,7 +140,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -170,7 +170,7 @@ EOF
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 2 processes
+Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 processes
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -186,7 +186,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 2 processes
+Processing 2 movies in segments of 50, batches of 50, 1 rounds, 1 batches in 2 processes
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB
@@ -216,7 +216,7 @@ EOF
         if ($this->isSymfony3()) {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  1/2 [==============>-------------]  50% < 1 sec/< 1 sec 10.0 MiB
@@ -232,7 +232,7 @@ EOF
         } else {
             $this->assertSame(
                 <<<'EOF'
-Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batch in 1 process
+Processing 2 movies in segments of 50, batches of 50, 1 round, 1 batches in 1 process
 
  0/2 [>---------------------------]   0% < 1 sec/< 1 sec 10.0 MiB
  2/2 [============================] 100% < 1 sec/< 1 sec 10.0 MiB


### PR DESCRIPTION
Extracted from #29

This PR simplifies the `ParallelizationInput` introduced in #29 to stick to being a typesafe Symfony Input wrapper.