### PR TITLE
Remove ItemBatchIterator#batchSize

### DIFF
--- a/src/ItemBatchIterator.php
+++ b/src/ItemBatchIterator.php
@@ -28,7 +28,6 @@ final class ItemBatchIterator
 {
     private $items;
     private $numberOfItems;
-    private $batchSize;
     private $itemsChunks;
 
     /**
@@ -52,7 +51,6 @@ final class ItemBatchIterator
             false,
         );
         $this->numberOfItems = count($this->items);
-        $this->batchSize = $batchSize;
     }
 
     /**
@@ -88,11 +86,6 @@ final class ItemBatchIterator
     public function getNumberOfItems(): int
     {
         return $this->numberOfItems;
-    }
-
-    public function getBatchSize(): int
-    {
-        return $this->batchSize;
     }
 
     /**

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -259,17 +259,17 @@ trait Parallelization
 
         $isNumberOfProcessesDefined = $parallelizationInput->isNumberOfProcessesDefined();
         $numberOfProcesses = $parallelizationInput->getNumberOfProcesses();
+        $batchSize = $this->getBatchSize();
 
         $itemBatchIterator = ItemBatchIterator::create(
             $parallelizationInput->getItem(),
             function () use ($input) {
                 return $this->fetchItems($input);
             },
-            $this->getBatchSize(),
+            $batchSize,
         );
 
         $numberOfItems = $itemBatchIterator->getNumberOfItems();
-        $batchSize = $this->getBatchSize();
 
         $config = new Configuration(
             $isNumberOfProcessesDefined,

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -269,7 +269,7 @@ trait Parallelization
         );
 
         $numberOfItems = $itemBatchIterator->getNumberOfItems();
-        $batchSize = $itemBatchIterator->getBatchSize();
+        $batchSize = $this->getBatchSize();
 
         $config = new Configuration(
             $isNumberOfProcessesDefined,

--- a/tests/ItemBatchIteratorTest.php
+++ b/tests/ItemBatchIteratorTest.php
@@ -40,7 +40,6 @@ final class ItemBatchIteratorTest extends TestCase
             $iterator,
             $expectedItems,
             $expectedNumberOfItems,
-            $batchSize,
             $expectedBatches,
         );
     }
@@ -66,7 +65,6 @@ final class ItemBatchIteratorTest extends TestCase
             $iterator,
             $expectedItems,
             $expectedNumberOfItems,
-            $batchSize,
             $expectedBatches,
         );
     }
@@ -213,12 +211,10 @@ final class ItemBatchIteratorTest extends TestCase
         ItemBatchIterator $iterator,
         array $expectedItems,
         int $expectedNumberOfItems,
-        int $expectedBatchSize,
         array $expectedBatches
     ): void {
         self::assertSame($expectedItems, $iterator->getItems());
         self::assertSame($expectedNumberOfItems, $iterator->getNumberOfItems());
-        self::assertSame($expectedBatchSize, $iterator->getBatchSize());
         self::assertSame($expectedBatches, $iterator->getItemBatches());
     }
 }


### PR DESCRIPTION
The batch size comes directly from `Command::getBatchSize()` so there is no reason to duplicate this state to the `ItemBatchIterator`.