### PR TITLE
Rework ChunkedItemsIterator

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,6 @@ parameters:
           message: '#Parameter \#1 \$command of class Symfony\\Component\\Process\\Process constructor expects array, string given\.#'
 
         - path: tests/ChunkedItemsIteratorTest.php
-          message: '#ChunkedItemsIterator::create\(\) expects Closure\(\)#'
+          message: '#Parameter \#2 \$fetchItems of static method .+ChunkedItemsIterator::fromItemOrCallable\(\) expects callable\(\)#'
 
         - '#unknown class Symfony\\Component\\DependencyInjection\\ResettableContainerInterface#'

--- a/src/ChunkedItemsIterator.php
+++ b/src/ChunkedItemsIterator.php
@@ -16,7 +16,6 @@ namespace Webmozarts\Console\Parallelization;
 use function array_chunk;
 use function array_filter;
 use function array_values;
-use Closure;
 use function count;
 use function explode;
 use function get_class;
@@ -77,7 +76,7 @@ final class ChunkedItemsIterator
     /**
      * @param callable():list<string> $fetchItems
      */
-    public static function fromItemOrCallable(?string $item, Closure $fetchItems, int $batchSize): self
+    public static function fromItemOrCallable(?string $item, callable $fetchItems, int $batchSize): self
     {
         if (null !== $item) {
             $items = [$item];

--- a/src/ChunkedItemsIterator.php
+++ b/src/ChunkedItemsIterator.php
@@ -14,14 +14,18 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization;
 
 use function array_chunk;
+use function array_filter;
 use function array_values;
 use Closure;
 use function count;
+use function explode;
 use function get_class;
 use function gettype;
 use function is_numeric;
 use function is_object;
+use const PHP_EOL;
 use function sprintf;
+use function stream_get_contents;
 use Webmozart\Assert\Assert;
 
 final class ChunkedItemsIterator
@@ -47,18 +51,33 @@ final class ChunkedItemsIterator
      */
     public function __construct(array $items, int $batchSize)
     {
-        $this->items = self::normalizeItems($items);
-        $this->itemsChunks = array_chunk(
-            $this->items,
-            $batchSize,
-        );
+        $this->items = $items;
+        $this->itemsChunks = array_chunk($this->items, $batchSize);
         $this->numberOfItems = count($this->items);
     }
 
     /**
-     * @param Closure(): list<string> $fetchItems
+     * @param resource$stream
      */
-    public static function create(?string $item, Closure $fetchItems, int $batchSize): self
+    public static function fromStream($stream, int $batchSize): self
+    {
+        return new self(
+            self::normalizeItems(
+                array_filter(
+                    explode(
+                        PHP_EOL,
+                        stream_get_contents($stream),
+                    ),
+                ),
+            ),
+            $batchSize,
+        );
+    }
+
+    /**
+     * @param callable():list<string> $fetchItems
+     */
+    public static function fromItemOrCallable(?string $item, Closure $fetchItems, int $batchSize): self
     {
         if (null !== $item) {
             $items = [$item];
@@ -69,12 +88,16 @@ final class ChunkedItemsIterator
                 $items,
                 sprintf(
                     'Expected the fetched items to be a list of strings. Got "%s".',
+                    // TODO: use get_debug_type when dropping support for PHP 7.4
                     gettype($items),
                 ),
             );
         }
 
-        return new self($items, $batchSize);
+        return new self(
+            self::normalizeItems($items),
+            $batchSize,
+        );
     }
 
     /**
@@ -102,9 +125,11 @@ final class ChunkedItemsIterator
     }
 
     /**
+     * @psalm-assert string[] $items
+     *
      * @return list<string>
      */
-    private static function normalizeItems($items): array
+    private static function normalizeItems(array $items): array
     {
         foreach ($items as $index => $item) {
             if (is_numeric($item)) {
@@ -117,6 +142,7 @@ final class ChunkedItemsIterator
                 $item,
                 sprintf(
                     'The items are potentially passed to the child processes via the STDIN. For this reason they are expected to be string values. Got "%s" for the item "%s".',
+                    // TODO: use get_debug_type when dropping PHP 7.4 support
                     is_object($item) ? get_class($item) : gettype($item),
                     $index,
                 ),

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -19,15 +19,12 @@ use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_slice;
-use function explode;
 use function getcwd;
 use function implode;
-use const PHP_EOL;
 use function realpath;
 use RuntimeException;
 use function sprintf;
 use const STDIN;
-use function stream_get_contents;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -263,11 +260,9 @@ trait Parallelization
         $batchSize = $this->getValidatedBatchSize();
         $segmentSize = $this->getValidatedSegmentSize();
 
-        $itemIterator = ChunkedItemsIterator::create(
+        $itemIterator = ChunkedItemsIterator::fromItemOrCallable(
             $parallelizationInput->getItem(),
-            function () use ($input) {
-                return $this->fetchItems($input);
-            },
+            fn () => $this->fetchItems($input),
             $batchSize,
         );
 
@@ -400,13 +395,8 @@ trait Parallelization
     ): void {
         $advancementChar = self::getProgressSymbol();
 
-        $itemIterator = new ChunkedItemsIterator(
-            array_filter(
-                explode(
-                    PHP_EOL,
-                    stream_get_contents(STDIN),
-                ),
-            ),
+        $itemIterator = ChunkedItemsIterator::fromStream(
+            STDIN,
             $this->getValidatedBatchSize(),
         );
 


### PR DESCRIPTION
- Introduce a `::fromStream()` static factory which makes it more convenient to create the iterator for `STDIN` whilst allowing testing easily without relying on `STDIN`
- Rename `::create()` to `::fromItemOrCallable()`
- Move the normalization of items from `__construct()` to the static factories, this makes testing a lot easier
- Simplify some tests: when testing the static factories we are only interested in the items themselves since the batchSize is just forwarded. The chunk logic is tested when testing the constructor directly