### PR TITLE
Introduce InputOptionsSerializer

### DIFF
--- a/src/InputOptionsSerializer.php
+++ b/src/InputOptionsSerializer.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use function array_diff_key;
+use function array_fill_keys;
+use function array_keys;
+use function array_map;
+use function implode;
+use function is_string;
+use function preg_match;
+use function sprintf;
+use function str_replace;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+final class InputOptionsSerializer
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param string[] $excludedOptionNames
+     *
+     * @return string[]
+     */
+    public static function serialize(
+        InputDefinition $commandDefinition,
+        InputInterface $input,
+        array $excludedOptionNames
+    ): array {
+        $filteredOptions = array_diff_key(
+            $input->getOptions(),
+            array_fill_keys($excludedOptionNames, ''),
+        );
+
+        return array_map(
+            static fn (string $name) => self::serializeOption(
+                $commandDefinition->getOption($name),
+                $name,
+                $filteredOptions[$name],
+            ),
+            array_keys($filteredOptions),
+        );
+    }
+
+    /**
+     * @param string|bool|int|float|null|array<string|bool|int|float|null> $value
+     */
+    private static function serializeOption(
+        InputOption $option,
+        string $name,
+        $value
+    ): string {
+        if ($option->isNegatable()) {
+            return sprintf(
+                '--%s%s',
+                $value ? '' : 'no-',
+                $name,
+            );
+        }
+
+        if (!$option->acceptValue()) {
+            return sprintf(
+                '--%s',
+                $name,
+            );
+        }
+
+        if ($option->isArray()) {
+            return implode(
+                '',
+                array_map(
+                    static fn ($item) => self::serializeOptionWithValue($name, $item),
+                    $value,
+                ),
+            );
+        }
+
+        return self::serializeOptionWithValue($name, $value);
+    }
+
+    /**
+     * @param string|bool|int|float|null|array<string|bool|int|float|null> $value
+     */
+    private static function serializeOptionWithValue(
+        string $name,
+        $value
+    ): string {
+        return sprintf(
+            '--%s=%s',
+            $name,
+            self::quoteOptionValue($value),
+        );
+    }
+
+    /**
+     * Ensure that an option value is quoted correctly before it is passed to a
+     * child process.
+     *
+     * @param string|bool|int|float|null $value
+     *
+     * @return string|bool|int|float|null
+     */
+    private static function quoteOptionValue($value)
+    {
+        if (self::isValueRequiresQuoting($value)) {
+            return sprintf(
+                '"%s"',
+                str_replace('"', '\"', $value),
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Validate whether a command option requires quoting.
+     */
+    private static function isValueRequiresQuoting($value): bool
+    {
+        return is_string($value) && 0 < preg_match('/[\s\W]/x', $value);
+    }
+}

--- a/tests/InputOptionsSerializerTest.php
+++ b/tests/InputOptionsSerializerTest.php
@@ -1,0 +1,282 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Webmozarts\Console\Parallelization\Fixtures\Command\NoSubProcessCommand;
+use Webmozarts\Console\Parallelization\Integration\Kernel;
+
+/**
+ * @covers \Webmozarts\Console\Parallelization\InputOptionsSerializer
+ */
+final class InputOptionsSerializerTest extends TestCase
+{
+    /**
+     * @dataProvider optionsProvider
+     */
+    public function test_it_can_reverse_the_options_parsing(
+        InputDefinition $commandDefinition,
+        InputInterface $input,
+        array $excludedParameters,
+        array $expected
+    ): void {
+        $input->bind($commandDefinition);
+
+        $actual = InputOptionsSerializer::serialize(
+            $commandDefinition,
+            $input,
+            $excludedParameters,
+        );
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function optionsProvider(): iterable
+    {
+        $completeInputDefinition = new InputDefinition([
+            new InputArgument(
+                'arg1',
+                InputArgument::REQUIRED,
+                'Argument without a default value',
+            ),
+            new InputArgument(
+                'arg2',
+                InputArgument::OPTIONAL,
+                'Argument with a default value',
+                'arg2DefaultValue',
+            ),
+            new InputOption(
+                'opt1',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Option with a default value',
+                'opt1DefaultValue',
+            ),
+            new InputOption(
+                'opt2',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Option without a default value',
+            ),
+        ]);
+
+        yield 'empty input and empty definition' => [
+            new InputDefinition(),
+            new ArrayInput([]),
+            [],
+            [],
+        ];
+
+        yield 'empty input and definition with default values' => [
+            new InputDefinition([
+                new InputArgument(
+                    'arg1',
+                    InputArgument::OPTIONAL,
+                    'Argument with a default value',
+                    'arg1DefaultValue',
+                ),
+                new InputOption(
+                    'opt1',
+                    null,
+                    InputOption::VALUE_REQUIRED,
+                    'Option with a default value',
+                    'opt1DefaultValue',
+                ),
+            ]),
+            new ArrayInput([]),
+            [],
+            ['--opt1=opt1DefaultValue'],
+        ];
+
+        yield 'input & options' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                'arg2' => 'arg2Value',
+                '--opt2' => 'opt2Value',
+            ]),
+            [],
+            [
+                '--opt1=opt1DefaultValue',
+                '--opt2=opt2Value',
+            ],
+        ];
+
+        yield 'input & options with excluded option passed option' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                'arg2' => 'arg2Value',
+                '--opt2' => 'opt2Value',
+            ]),
+            ['opt2'],
+            ['--opt1=opt1DefaultValue'],
+        ];
+
+        yield 'input & options with excluded option default option' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                'arg2' => 'arg2Value',
+                '--opt2' => 'opt2Value',
+            ]),
+            ['opt1'],
+            ['--opt2=opt2Value'],
+        ];
+
+        yield 'nominal' => [
+            self::createIntegrationInputDefinition(),
+            new ArrayInput([
+                'command' => 'test:no-subprocess',
+                'item' => null,
+                '--processes' => '1',
+                '--env' => 'dev',
+            ]),
+            ['child', 'processes'],
+            ['--env=dev'],
+        ];
+
+        yield from self::optionSerializationProvider();
+    }
+
+    private static function optionSerializationProvider(): iterable
+    {
+        $createSet = static fn (
+            InputOption $option,
+            array $input,
+            array $expected
+        ) => [
+            new InputDefinition([$option]),
+            new ArrayInput($input),
+            [],
+            $expected,
+        ];
+
+        yield 'option without value' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NONE,
+            ),
+            ['--opt' => null],
+            ['--opt'],
+        );
+
+        yield 'option without value by shortcut' => $createSet(
+            new InputOption(
+                'opt',
+                'o',
+                InputOption::VALUE_NONE,
+            ),
+            ['-o' => null],
+            ['--opt'],
+        );
+
+        yield 'option with value required' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => 'foo'],
+            ['--opt=foo'],
+        );
+
+        yield 'option with value requiring escaping' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => '"o_id in(\'20\')"'],
+            ['--opt="\"o_id in(\'20\')\""'],
+        );
+
+        yield 'option with non string value (bool)' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => true],
+            ['--opt=1'],
+        );
+
+        yield 'option with non string value (int)' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => 20],
+            ['--opt=20'],
+        );
+
+        yield 'option with non string value (float)' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED,
+            ),
+            ['--opt' => 5.3],
+            ['--opt=5.3'],
+        );
+
+        yield 'option with non string value (array of strings)' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            ),
+            ['--opt' => ['v1', 'v2', 'v3']],
+            ['--opt=v1--opt=v2--opt=v3'],
+        );
+
+        yield 'negatable option (positive)' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NEGATABLE,
+            ),
+            ['--opt' => null],
+            ['--opt'],
+        );
+
+        yield 'negatable option (negative)' => $createSet(
+            new InputOption(
+                'opt',
+                null,
+                InputOption::VALUE_NEGATABLE,
+            ),
+            ['--no-opt' => null],
+            ['--no-opt'],
+        );
+    }
+
+    private static function createIntegrationInputDefinition(): InputDefinition
+    {
+        // We need the framework bundle application because the env and no-debug
+        // options are defined there.
+        $frameworkBundleApplication = new Application(new Kernel());
+
+        $command = new NoSubProcessCommand();
+        $command->setApplication($frameworkBundleApplication);
+        $command->mergeApplicationDefinition();
+
+        return $command->getDefinition();
+    }
+}


### PR DESCRIPTION
In #28, the feature to forward the command options was introduced. It had to later be followed up by #41, #42 in order to fix the issue where the option value may require quoting. This piece of code is heavily under-tested (and it was really hard to test it as is) and is prone to bugs (I found 2 adding tests).

In this PR, I'm extracting this element into `InputOptionsSerializer` as a closed piece (static & final) as IMO there is no need to make it extensible: if broken it needs to be fixed. This extraction allows much easier testing.

This PR also fixes:

- the case of negatable options
- detection quoting with may fail to detect some special characters