### PR TITLE
Remove unused methods

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -419,28 +419,6 @@ trait Parallelization
     }
 
     /**
-     * Ensure that an option value is quoted correctly, before it is passed to a child process.
-     * @param  mixed $value the input option value, which is typically a string but can be of any other primitive type
-     * @return mixed the replaced and quoted value, if $value contained a character that required quoting
-     */
-    protected function quoteOptionValue($value)
-    {
-        if ($this->isValueRequiresQuoting($value)) {
-            return sprintf('"%s"', str_replace('"', '\"', $value));
-        }
-
-        return $value;
-    }
-
-    /**
-     * Validate whether a command option requires quoting or not, depending on its content.
-     */
-    protected function isValueRequiresQuoting($value): bool
-    {
-        return 0 < preg_match('/[\s \\\\ \' " & | < > = ! @]/x', (string) $value);
-    }
-
-    /**
      * @internal
      * @return positive-int
      */


### PR DESCRIPTION
Those methods have been moved to `InputOptionsSerializer` as part of #77.