### PR TITLE
Fix forwarding options

### DIFF
--- a/src/InputOptionsSerializer.php
+++ b/src/InputOptionsSerializer.php
@@ -43,7 +43,7 @@ final class InputOptionsSerializer
         array $excludedOptionNames
     ): array {
         $filteredOptions = array_diff_key(
-            $input->getOptions(),
+            RawOptionsInput::getRawOptions($input),
             array_fill_keys($excludedOptionNames, ''),
         );
 

--- a/src/RawOptionsInput.php
+++ b/src/RawOptionsInput.php
@@ -40,12 +40,12 @@ final class RawOptionsInput extends Input
             : [];
     }
 
-    public function getFirstArgument()
+    public function getFirstArgument(): ?string
     {
         throw new DomainException('Not implemented.');
     }
 
-    public function hasParameterOption($values, bool $onlyParams = false)
+    public function hasParameterOption($values, bool $onlyParams = false): bool
     {
         throw new DomainException('Not implemented.');
     }
@@ -55,7 +55,7 @@ final class RawOptionsInput extends Input
         throw new DomainException('Not implemented.');
     }
 
-    protected function parse()
+    protected function parse(): void
     {
         throw new DomainException('Not implemented.');
     }

--- a/src/RawOptionsInput.php
+++ b/src/RawOptionsInput.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
@@ -14,19 +23,21 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 final class RawOptionsInput extends Input
 {
-    private function __construct(InputDefinition $definition = null)
+    private function __construct(?InputDefinition $definition = null)
     {
         parent::__construct($definition);
     }
 
+    /**
+     * Returns all the given options NOT merged with the default values.
+     *
+     * @return array<string|bool|int|float|null|array<string|bool|int|float|null>>
+     */
     public static function getRawOptions(InputInterface $input): array
     {
-        return $input->options;
-    }
-
-    protected function parse()
-    {
-        throw new DomainException('Not implemented.');
+        return $input instanceof Input
+            ? $input->options
+            : [];
     }
 
     public function getFirstArgument()
@@ -40,6 +51,11 @@ final class RawOptionsInput extends Input
     }
 
     public function getParameterOption($values, $default = false, bool $onlyParams = false)
+    {
+        throw new DomainException('Not implemented.');
+    }
+
+    protected function parse()
     {
         throw new DomainException('Not implemented.');
     }

--- a/src/RawOptionsInput.php
+++ b/src/RawOptionsInput.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use DomainException;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @internal
+ */
+final class RawOptionsInput extends Input
+{
+    private function __construct(InputDefinition $definition = null)
+    {
+        parent::__construct($definition);
+    }
+
+    public static function getRawOptions(InputInterface $input): array
+    {
+        return $input->options;
+    }
+
+    protected function parse()
+    {
+        throw new DomainException('Not implemented.');
+    }
+
+    public function getFirstArgument()
+    {
+        throw new DomainException('Not implemented.');
+    }
+
+    public function hasParameterOption($values, bool $onlyParams = false)
+    {
+        throw new DomainException('Not implemented.');
+    }
+
+    public function getParameterOption($values, $default = false, bool $onlyParams = false)
+    {
+        throw new DomainException('Not implemented.');
+    }
+}

--- a/tests/ChunkedItemsIteratorTest.php
+++ b/tests/ChunkedItemsIteratorTest.php
@@ -196,9 +196,9 @@ final class ChunkedItemsIteratorTest extends TestCase
             self::createStream(<<<'STDIN'
                 item0
                 item1
-            
+
                 item3
-            
+
                 item4
                 STDIN),
             ['item0', 'item1', 'item3', 'item4'],

--- a/tests/InputOptionsSerializerTest.php
+++ b/tests/InputOptionsSerializerTest.php
@@ -102,13 +102,24 @@ final class InputOptionsSerializerTest extends TestCase
             ]),
             new ArrayInput([]),
             [],
-            ['--opt1=opt1DefaultValue'],
+            [],
         ];
 
         yield 'input & options' => [
             $completeInputDefinition,
             new ArrayInput([
                 'arg2' => 'arg2Value',
+                '--opt2' => 'opt2Value',
+            ]),
+            [],
+            ['--opt2=opt2Value'],
+        ];
+
+        yield 'input & options with default value' => [
+            $completeInputDefinition,
+            new ArrayInput([
+                'arg2' => 'arg2Value',
+                '--opt1' => 'opt1DefaultValue',
                 '--opt2' => 'opt2Value',
             ]),
             [],
@@ -125,7 +136,7 @@ final class InputOptionsSerializerTest extends TestCase
                 '--opt2' => 'opt2Value',
             ]),
             ['opt2'],
-            ['--opt1=opt1DefaultValue'],
+            [],
         ];
 
         yield 'input & options with excluded option default option' => [
@@ -145,17 +156,12 @@ final class InputOptionsSerializerTest extends TestCase
                 'item' => null,
                 '--processes' => '1',
                 '--env' => 'dev',
+                '--ansi' => null,
             ]),
             ['child', 'processes'],
             [
-                '--help',
-                '--quiet',
-                '--verbose',
-                '--version',
-                '--no-ansi',
-                '--no-interaction',
                 '--env=dev',
-                '--no-debug',
+                '--ansi',
             ],
         ];
 

--- a/tests/Integration/ParallelizationIntegrationTest.php
+++ b/tests/Integration/ParallelizationIntegrationTest.php
@@ -61,7 +61,7 @@ class ParallelizationIntegrationTest extends TestCase
 
         // TODO: note that the "in 1 process is incorrect here..."
         $expected = <<<'EOF'
-            Processing 5 items in segments of 5, batches of 2, 1 round, 1 batch in 1 process
+            Processing 5 items in segments of 2, batches of 2, 1 round, 1 batch in 1 process
 
              0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB
              5/5 [============================] 100% 10 secs/10 secs 10.0 MiB


### PR DESCRIPTION
Currently we are using `$input->getOptions()`. It turns out it is not a good idea since when doing so it adds the default values of the options registered in the input definition. This is a problem as:

- Those added options may not be necessary (from a user perspective it's redundant)
- Those options includes "special options": options that are handled in a different way in Symfony*

*: Example of such a special option. When adding `--version` when calling your command, the Symfony application will directly handle it calling `Application::getLongVersion()` (in `Application::doRun()`) and not call the command at all.