### PR TITLE
Improve the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,74 @@
+# See https://tech.davis-hansson.com/p/make/
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+
 .DEFAULT_GOAL := help
 
+
+# Global variables
 OS := $(shell uname)
 PHPNOGC=php -d zend.enable_gc=0
 CCYELLOW=\033[0;33m
 CCEND=\033[0m
 
+# PHP specific variables
+PHP_CS_FIXER_BIN = vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer
+PHP_CS_FIXER = $(PHPNOGC) $(PHP_CS_FIXER_BIN)
 PHPSTAN_BIN = vendor/phpstan/phpstan/phpstan
 PHPSTAN = $(PHPSTAN_BIN)
-
-.PHONY: help
-help:
-	@echo "\033[33mUsage:\033[0m\n  make TARGET\n\n\033[32m#\n# Commands\n#---------------------------------------------------------------------------\033[0m\n"
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
+PHPUNIT_BIN = vendor/bin/phpunit
+PHPUNIT = $(PHPUNIT_BIN)
 
 
 #
 # Commands
 #---------------------------------------------------------------------------
 
+.PHONY: help
+help:
+	@echo "\033[33mUsage:\033[0m\n  make TARGET\n\n\033[32m#\n# Commands\n#---------------------------------------------------------------------------\033[0m\n"
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
+
 .PHONY: cs
-PHP_CS_FIXER=vendor/bin/php-cs-fixer
-cs:	## Fixes CS
-cs: $(PHP_CS_FIXER)
-	$(PHPNOGC) $(PHP_CS_FIXER) fix
+cs: 	 ## Fixes CS
+cs: php_cs_fixer gitignore_sort
+
+.PHONY: php_cs_fixer
+php_cs_fixer: # Runs PHP-CS-Fixer
+php_cs_fixer: $(PHP_CS_FIXER_BIN)
+	$(PHP_CS_FIXER) fix
+
+.PHONY: gitignore_sort
+gitignore_sort:	# Sorts the .gitignore entries
+gitignore_sort:
 	LC_ALL=C sort -u .gitignore -o .gitignore
 
+.PHONY: test
+test: 	 ## Runs all the tests
+test: clear-cache validate-package phpstan phpunit
 
 .PHONY: phpstan
-phpstan: ## Runs PHPStan
+phpstan: # Runs PHPStan
 phpstan: $(PHPSTAN_BIN) vendor
 ifndef SKIP_PHPSTAN
 	$(PHPSTAN) analyze
 endif
 
-
-#
-# Tests
-#---------------------------------------------------------------------------
-
-PHPUNIT=vendor/bin/phpunit
-test:	## Runs the tests
-test: $(PHPUNIT)
+.PHONY: phpunit
+phpunit:	# Runs PHPUnit
+phpunit: $(PHPUNIT_BIN)
 	$(PHPUNIT)
+
+.PHONY: validate-package
+validate-package: # Validates the Composer package
+validate-package: vendor
+	composer validate --strict
+
+.PHONY: clear-cache
+clear-cache: # Clears the integration test app cache
+clear-cache:
+	rm -rf tests/Integration/**/cache || true
 
 
 #
@@ -56,13 +83,12 @@ vendor: composer.lock
 	composer install
 	touch $@
 
-$(PHP_CS_FIXER): vendor
+$(PHP_CS_FIXER_BIN): vendor
+	composer bin php-cs-fixer install
 	touch $@
 
 $(PHPSTAN_BIN): vendor
-ifndef SKIP_PHPSTAN
 	touch $@
-endif
 
-$(PHPUNIT): vendor
+$(PHPUNIT_BIN): vendor
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
 
-.DEFAULT_GOAL := help
+.DEFAULT_GOAL := all
 
 
 # Global variables
@@ -25,48 +25,51 @@ PHPUNIT = $(PHPUNIT_BIN)
 # Commands
 #---------------------------------------------------------------------------
 
+.PHONY: all
+all: cs test
+
 .PHONY: help
 help:
 	@echo "\033[33mUsage:\033[0m\n  make TARGET\n\n\033[32m#\n# Commands\n#---------------------------------------------------------------------------\033[0m\n"
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
 
 .PHONY: cs
-cs: 	 ## Fixes CS
+cs: 	 	  ## Fixes CS
 cs: php_cs_fixer gitignore_sort
 
 .PHONY: php_cs_fixer
-php_cs_fixer: # Runs PHP-CS-Fixer
+php_cs_fixer: 	  ## Runs PHP-CS-Fixer
 php_cs_fixer: $(PHP_CS_FIXER_BIN)
 	$(PHP_CS_FIXER) fix
 
 .PHONY: gitignore_sort
-gitignore_sort:	# Sorts the .gitignore entries
+gitignore_sort:	  ## Sorts the .gitignore entries
 gitignore_sort:
 	LC_ALL=C sort -u .gitignore -o .gitignore
 
 .PHONY: test
-test: 	 ## Runs all the tests
+test: 	 	  ## Runs all the tests
 test: clear-cache validate-package phpstan phpunit
 
 .PHONY: phpstan
-phpstan: # Runs PHPStan
+phpstan: 	  ## Runs PHPStan
 phpstan: $(PHPSTAN_BIN) vendor
 ifndef SKIP_PHPSTAN
 	$(PHPSTAN) analyze
 endif
 
 .PHONY: phpunit
-phpunit:	# Runs PHPUnit
+phpunit:	  ## Runs PHPUnit
 phpunit: $(PHPUNIT_BIN)
 	$(PHPUNIT)
 
 .PHONY: validate-package
-validate-package: # Validates the Composer package
+validate-package: ## Validates the Composer package
 validate-package: vendor
 	composer validate --strict
 
 .PHONY: clear-cache
-clear-cache: # Clears the integration test app cache
+clear-cache: 	  ## Clears the integration test app cache
 clear-cache:
 	rm -rf tests/Integration/**/cache || true
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Contributions to the package are always welcome!
 * Report any bugs or issues you find on the [issue tracker].
 * You can grab the source code at the package's [Git repository].
 
+To run the CS fixer and tests you can use the command `make`. More details
+available with `make help`.
+
+
 License
 -------
 


### PR DESCRIPTION
Make the Makefile more in line with the standard we are using at Webmozarts:

- all commands are available via `make help`
- some convenience meta commands are available `make cs`, `make test`
- all commands are isolated and can be run in isolation, e.g. `make php_cs_fixer`, `make phpstan`, `make phpunit`
- not giving any commands runs everything
- updated the contributing section to mention the Makefile