### PR TITLE
Add an error handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "ext-json": "*",
         "bamarni/composer-bin-plugin": "^1.8",
         "ergebnis/composer-normalize": "^2.28",
+        "jangregor/phpstan-prophecy": "^1.0",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.0",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0"
@@ -42,7 +45,8 @@
     "config": {
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true,
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "phpstan/extension-installer": true
         },
         "bamarni-bin": {
             "bin-links": false,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,8 +17,8 @@ parameters:
         - path: tests/Integration/ParallelizationIntegrationTest.php
           message: '#ParallelizationIntegrationTest::\$noSubProcessCommand#'
 
-        - path: src/ParallelExecutor.php
-          message: '#Call to method reset\(\) on an unknown class .*ResettableContainerInterface#'
-
         - path: tests/ChunkedItemsIteratorTest.php
           message: '#Parameter \#2 \$fetchItems of static method .+ChunkedItemsIterator::fromItemOrCallable\(\) expects callable\(\)#'
+
+        - path: src/ErrorHandler/ResetContainerErrorHandler.php
+          message: '#Property .*ResetContainerErrorHandler::\$container.*does not accept.*ContainerInterface\|null\.#'

--- a/src/ErrorHandler/ItemProcessingErrorHandler.php
+++ b/src/ErrorHandler/ItemProcessingErrorHandler.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use Throwable;
+
+interface ItemProcessingErrorHandler
+{
+    public function handleError(string $item, Throwable $throwable): void;
+}

--- a/src/ErrorHandler/ItemProcessingErrorHandlerLogger.php
+++ b/src/ErrorHandler/ItemProcessingErrorHandlerLogger.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\ErrorHandler;
@@ -22,7 +31,7 @@ final class ItemProcessingErrorHandlerLogger implements ItemProcessingErrorHandl
 
     public function handleError(string $item, Throwable $throwable): void
     {
-        $this->logger->processingItemFailed($item, $throwable);
+        $this->logger->logItemProcessingFailed($item, $throwable);
 
         $this->decoratedErrorHandler->handleError($item, $throwable);
     }

--- a/src/ErrorHandler/ItemProcessingErrorHandlerLogger.php
+++ b/src/ErrorHandler/ItemProcessingErrorHandlerLogger.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use Throwable;
+use Webmozarts\Console\Parallelization\Logger\Logger;
+
+final class ItemProcessingErrorHandlerLogger implements ItemProcessingErrorHandler
+{
+    private ItemProcessingErrorHandler $decoratedErrorHandler;
+    private Logger $logger;
+
+    public function __construct(
+        ItemProcessingErrorHandler $decoratedErrorHandler,
+        Logger $logger
+    ) {
+        $this->decoratedErrorHandler = $decoratedErrorHandler;
+        $this->logger = $logger;
+    }
+
+    public function handleError(string $item, Throwable $throwable): void
+    {
+        $this->logger->processingItemFailed($item, $throwable);
+
+        $this->decoratedErrorHandler->handleError($item, $throwable);
+    }
+}

--- a/src/ErrorHandler/ResetContainerErrorHandler.php
+++ b/src/ErrorHandler/ResetContainerErrorHandler.php
@@ -1,17 +1,29 @@
 <?php
 
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\ErrorHandler;
 
+use function interface_exists;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Throwable;
 use Webmozarts\Console\Parallelization\Symfony\ResettableContainerInterface;
-use function class_exists;
 
-final class ResetContainerErrorhandler implements ItemProcessingErrorHandler
+final class ResetContainerErrorHandler implements ItemProcessingErrorHandler
 {
+    /**
+     * @var (ContainerInterface&ResetInterface)|null
+     */
     private ?ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
@@ -29,12 +41,12 @@ final class ResetContainerErrorhandler implements ItemProcessingErrorHandler
     private static function isResettable(ContainerInterface $container): bool
     {
         return (
-                class_exists(ResetInterface::class)
-                && $container instanceof ResetInterface
-            )
+            interface_exists(ResetInterface::class)
+            && $container instanceof ResetInterface
+        )
             // TODO: to remove once we drop Symfony 4.4 support.
-            || (class_exists(ResettableContainerInterface::class)
-                && $container instanceof ResettableContainerInterface
+            || (interface_exists(ResettableContainerInterface::class)
+            && $container instanceof ResettableContainerInterface
             );
     }
 }

--- a/src/ErrorHandler/ResetContainerErrorhandler.php
+++ b/src/ErrorHandler/ResetContainerErrorhandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ResetInterface;
+use Throwable;
+use Webmozarts\Console\Parallelization\Symfony\ResettableContainerInterface;
+use function class_exists;
+
+final class ResetContainerErrorhandler implements ItemProcessingErrorHandler
+{
+    private ?ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = self::isResettable($container) ? $container : null;
+    }
+
+    public function handleError(string $item, Throwable $throwable): void
+    {
+        if (null !== $this->container) {
+            $this->container->reset();
+        }
+    }
+
+    private static function isResettable(ContainerInterface $container): bool
+    {
+        return (
+                class_exists(ResetInterface::class)
+                && $container instanceof ResetInterface
+            )
+            // TODO: to remove once we drop Symfony 4.4 support.
+            || (class_exists(ResettableContainerInterface::class)
+                && $container instanceof ResettableContainerInterface
+            );
+    }
+}

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\Logger;
 
+use Throwable;
+
 interface Logger
 {
     public function logConfiguration(
@@ -36,4 +38,6 @@ interface Logger
     public function logCommandStarted(string $commandName): void;
 
     public function logCommandFinished(): void;
+
+    public function processingItemFailed(string $item, Throwable $throwable): void;
 }

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -39,5 +39,5 @@ interface Logger
 
     public function logCommandFinished(): void;
 
-    public function processingItemFailed(string $item, Throwable $throwable): void;
+    public function logItemProcessingFailed(string $item, Throwable $throwable): void;
 }

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Logger;
 
 use Psr\Log\LoggerInterface;
-use Throwable;
 use function sprintf;
 use function str_pad;
 use const STR_PAD_BOTH;
 use function str_replace;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 use Webmozart\Assert\Assert;
 
 final class StandardLogger implements Logger
@@ -141,8 +141,13 @@ final class StandardLogger implements Logger
         $this->logger->debug('Command finished');
     }
 
-    public function processingItemFailed(string $item, Throwable $throwable): void
+    public function logItemProcessingFailed(string $item, Throwable $throwable): void
     {
-        // TODO: Implement processingItemFailed() method.
+        $this->output->writeln(sprintf(
+            "Failed to process \"%s\": %s\n%s",
+            trim($item),
+            $throwable->getMessage(),
+            $throwable->getTraceAsString(),
+        ));
     }
 }

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Logger;
 
 use Psr\Log\LoggerInterface;
+use Throwable;
 use function sprintf;
 use function str_pad;
 use const STR_PAD_BOTH;
@@ -138,5 +139,10 @@ final class StandardLogger implements Logger
     public function logCommandFinished(): void
     {
         $this->logger->debug('Command finished');
+    }
+
+    public function processingItemFailed(string $item, Throwable $throwable): void
+    {
+        // TODO: Implement processingItemFailed() method.
     }
 }

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -13,25 +13,21 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
-use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
-use Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorhandler;
 use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_slice;
-use function class_exists;
 use function getcwd;
 use function implode;
-use Psr\Container\ContainerInterface;
 use function sprintf;
 use const STDIN;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Contracts\Service\ResetInterface;
 use Throwable;
 use function trim;
 use Webmozart\Assert\Assert;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 use Webmozarts\Console\Parallelization\Logger\LoggerFactory;
 

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
-use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
-use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandlerLogger;
-use Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorhandler;
 use function getcwd;
 use function realpath;
 use RuntimeException;
@@ -29,6 +26,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandlerLogger;
+use Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorHandler;
 use Webmozarts\Console\Parallelization\Logger\DebugProgressBarFactory;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 use Webmozarts\Console\Parallelization\Logger\LoggerFactory;
@@ -286,7 +286,7 @@ trait Parallelization
 
     protected function createItemErrorHandler(Logger $logger): ItemProcessingErrorHandler
     {
-        $errorHandler = new ResetContainerErrorhandler(
+        $errorHandler = new ResetContainerErrorHandler(
             $this->getContainer(),
         );
 

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandlerLogger;
+use Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorhandler;
 use function getcwd;
 use function realpath;
 use RuntimeException;
@@ -232,8 +235,6 @@ trait Parallelization
             fn (InputInterface $input, OutputInterface $output, array $items) => $this->runBeforeBatch($input, $output, $items),
             fn (InputInterface $input, OutputInterface $output, array $items) => $this->runAfterBatch($input, $output, $items),
             fn (string $item, InputInterface $input, OutputInterface $output) => $this->runSingleCommand($item, $input, $output),
-            $this->logError,
-            $container,
             fn (int $count) => $this->getItemName($count),
             $this->getConsolePath(),
             self::detectPhpExecutable(),
@@ -254,6 +255,7 @@ trait Parallelization
                     return $this->logger;
                 }
             },
+            $this->createItemErrorHandler($logger),
         ))->execute(
             $parallelizationInput,
             $input,
@@ -280,6 +282,20 @@ trait Parallelization
             new DebugProgressBarFactory(),
             new ConsoleLogger($output),
         );
+    }
+
+    protected function createItemErrorHandler(Logger $logger): ItemProcessingErrorHandler
+    {
+        $errorHandler = new ResetContainerErrorhandler(
+            $this->getContainer(),
+        );
+
+        return $this->logError
+            ? new ItemProcessingErrorHandlerLogger(
+                $errorHandler,
+                $logger,
+            )
+            : $errorHandler;
     }
 
     /**

--- a/tests/ErrorHandler/ItemProcessingErrorHandlerLoggerTest.php
+++ b/tests/ErrorHandler/ItemProcessingErrorHandlerLoggerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use Error;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Webmozarts\Console\Parallelization\Logger\Logger;
+
+/**
+ * @covers \Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandlerLogger
+ */
+final class ItemProcessingErrorHandlerLoggerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function test_it_logs_and_forwards_the_error_handling_to_the_decorated_error_handler(): void
+    {
+        $item = 'item1';
+        $throwable = new Error('An error occurred.');
+
+        $decoratedErrorHandlerProphecy = $this->prophesize(ItemProcessingErrorHandler::class);
+        $loggerProphecy = $this->prophesize(Logger::class);
+
+        $errorHandler = new ItemProcessingErrorHandlerLogger(
+            $decoratedErrorHandlerProphecy->reveal(),
+            $loggerProphecy->reveal(),
+        );
+
+        $decoratedErrorHandlerProphecy
+            ->handleError($item, $throwable)
+            ->shouldBeCalledTimes(1);
+        $loggerProphecy
+            ->logItemProcessingFailed($item, $throwable)
+            ->shouldBeCalledTimes(1);
+
+        $errorHandler->handleError($item, $throwable);
+    }
+}

--- a/tests/ErrorHandler/NonResettableContainer.php
+++ b/tests/ErrorHandler/NonResettableContainer.php
@@ -13,9 +13,18 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\ErrorHandler;
 
-use Throwable;
+use DomainException;
+use Psr\Container\ContainerInterface;
 
-interface ItemProcessingErrorHandler
+final class NonResettableContainer implements ContainerInterface
 {
-    public function handleError(string $item, Throwable $throwable): void;
+    public function get(string $id)
+    {
+        throw new DomainException('Unexpected call.');
+    }
+
+    public function has(string $id)
+    {
+        throw new DomainException('Unexpected call.');
+    }
 }

--- a/tests/ErrorHandler/NonResettableContainer.php
+++ b/tests/ErrorHandler/NonResettableContainer.php
@@ -23,7 +23,7 @@ final class NonResettableContainer implements ContainerInterface
         throw new DomainException('Unexpected call.');
     }
 
-    public function has(string $id)
+    public function has(string $id): bool
     {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/ErrorHandler/ResetContainerErrorhandlerTest.php
+++ b/tests/ErrorHandler/ResetContainerErrorhandlerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use Error;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorHandler
+ */
+final class ResetContainerErrorhandlerTest extends TestCase
+{
+    public function test_it_does_nothing_if_the_container_is_not_resettable(): void
+    {
+        $errorHandler = new ResetContainerErrorHandler(
+            new NonResettableContainer(),
+        );
+
+        self::handleError($errorHandler);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_it_resets_the_container_if_the_container_is_resettable(): void
+    {
+        $container = new ResettableContainer();
+
+        $errorHandler = new ResetContainerErrorHandler($container);
+
+        // Sanity check
+        self::assertFalse($container->reset);
+
+        self::handleError($errorHandler);
+
+        self::assertTrue($container->reset);
+    }
+
+    private static function handleError(ItemProcessingErrorHandler $errorHandler): void
+    {
+        $errorHandler->handleError(
+            'item0',
+            new Error('An error occurred.'),
+        );
+    }
+}

--- a/tests/ErrorHandler/ResettableContainer.php
+++ b/tests/ErrorHandler/ResettableContainer.php
@@ -26,7 +26,7 @@ final class ResettableContainer implements ContainerInterface, ResetInterface
         throw new DomainException('Unexpected call.');
     }
 
-    public function has(string $id)
+    public function has(string $id): bool
     {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/ErrorHandler/ResettableContainer.php
+++ b/tests/ErrorHandler/ResettableContainer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use DomainException;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+final class ResettableContainer implements ContainerInterface, ResetInterface
+{
+    public bool $reset = false;
+
+    public function get(string $id)
+    {
+        throw new DomainException('Unexpected call.');
+    }
+
+    public function has(string $id)
+    {
+        throw new DomainException('Unexpected call.');
+    }
+
+    public function reset(): void
+    {
+        $this->reset = true;
+    }
+}

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -172,8 +172,6 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_can_log_an_item_processing_failure(): void
     {
-        $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-
         $this->logger->logItemProcessingFailed('item1', new Error('An error occurred.'));
 
         self::assertStringStartsWith(

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\Logger;
 
+use Error;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -167,5 +168,17 @@ final class StandardLoggerTest extends TestCase
             TXT;
 
         self::assertSame($expected, $this->output->fetch());
+    }
+
+    public function test_it_can_log_an_item_processing_failure(): void
+    {
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+
+        $this->logger->logItemProcessingFailed('item1', new Error('An error occurred.'));
+
+        self::assertStringStartsWith(
+            'Failed to process "item1": An error occurred.',
+            $this->output->fetch(),
+        );
     }
 }


### PR DESCRIPTION
Back when we were confronted with the issue of error handling we settled for a quick and easy solution. This current solution has several flaws:

- It has some Container (i.e. incompatible with non Symfony app) dependent code
- It offers no convenient extension point
- Offers toggled global based behaviour which in this peculiar instance is not inherently bad but is not ideal neither

For this reason I'm introducing an error handler interface. This offers a better extension point and clearer code as well. The current implementation aims to stay in line with the existing behaviour.

Note that a bug has been fixed which is that current the Container was never reset even if resettable (due to `class_exists()` returning `false` – should be `interface_exists()`).