### PR TITLE
Add infection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,36 @@ jobs:
         runs-on: "ubuntu-latest"
         name: "Test ${{ matrix.php }}"
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 php:
                     - "7.4"
                     - "8.0"
+                    - "8.1"
+
+        steps:
+            -   name: "Check out repository code"
+                uses: "actions/checkout@v2"
+
+            -   name: "Setup PHP"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    php-version: "${{ matrix.php }}"
+                    tools: "composer"
+
+            -   name: "Install Composer dependencies"
+                uses: "ramsey/composer-install@v2"
+
+            -   name: "Run tests"
+                run: "make test"
+
+    infection:
+        runs-on: "ubuntu-latest"
+        name: "Infection ${{ matrix.php }}"
+        strategy:
+            fail-fast: false
+            matrix:
+                php:
                     - "8.1"
 
         steps:
@@ -32,5 +57,5 @@ jobs:
             -   name: "Install Composer dependencies"
                 uses: "ramsey/composer-install@v2"
 
-            -   name: "Run tests"
-                run: "make test"
+            -   name: "Run tests with coverage and Infection"
+                run: "make infection"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+!/dist/.gitkeep
 !/tests/Integration/var/.gitkeep
 /.idea
 /.php-cs-fixer.cache
@@ -5,7 +6,6 @@
 /.phpunit.result.cache
 /composer.lock
 /dist/
-!/dist/.gitkeep
 /tests/Integration/output
 /tests/Integration/var/
 /vendor-bin/*/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /.php_cs.cache
 /.phpunit.result.cache
 /composer.lock
+/dist/
+!/dist/.gitkeep
 /tests/Integration/output
 /tests/Integration/var/
 /vendor-bin/*/vendor/

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ $(PHPUNIT_BIN): vendor
 	touch $@
 
 $(COVERAGE_DIR): $(PHPUNIT_BIN) src tests phpunit.xml.dist
-	$(MAKE) phpunit_coverage
+	$(MAKE) phpunit_coverage_infection
 	$(TOUCH) "$@"
 
 $(INFECTION_BIN): vendor

--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,20 @@ validate-package: ## Validates the Composer package
 validate-package: vendor
 	composer validate --strict
 
+.PHONY: clear
+clear: 	  	  ## Clears various artifacts
+clear: clear-cache clear-coverage
+
 .PHONY: clear-cache
 clear-cache: 	  ## Clears the integration test app cache
 clear-cache:
 	rm -rf tests/Integration/**/cache || true
+
+.PHONY: clear-coverage
+clear-coverage:	  ## Clears the coverage reports
+clear-coverage:
+	rm -rf dist/phpunit* || true
+	rm -rf dist/coverage* || true
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CCYELLOW=\033[0;33m
 CCEND=\033[0m
 
 # PHP specific variables
-COVERAGE_DIR = dist/coverage
+COVERAGE_DIR = dist/coverage-xml
 TARGET_MSI = 50
 
 PHP_CS_FIXER_BIN = vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ CCYELLOW=\033[0;33m
 CCEND=\033[0m
 
 # PHP specific variables
-COVERAGE_DIR = dist/coverage-xml
+COVERAGE_DIR = dist/coverage
+COVERAGE_XML = $(COVERAGE_DIR)/xml
+COVERAGE_HTML = $(COVERAGE_DIR)/html
 TARGET_MSI = 50
 
 PHP_CS_FIXER_BIN = vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer
@@ -22,8 +24,8 @@ PHPSTAN_BIN = vendor/phpstan/phpstan/phpstan
 PHPSTAN = $(PHPSTAN_BIN)
 PHPUNIT_BIN = vendor/bin/phpunit
 PHPUNIT = $(PHPUNIT_BIN)
-PHPUNIT_COVERAGE_INFECTION = XDEBUG_MODE=coverage $(PHPUNIT) --coverage-xml=$(COVERAGE_DIR)/coverage-xml --log-junit=$(COVERAGE_DIR)/phpunit.junit.xml
-PHPUNIT_COVERAGE_HTML = XDEBUG_MODE=coverage $(PHPUNIT) --coverage-html=$(COVERAGE_DIR)/coverage-html
+PHPUNIT_COVERAGE_INFECTION = XDEBUG_MODE=coverage $(PHPUNIT) --coverage-xml=$(COVERAGE_XML) --log-junit=$(COVERAGE_DIR)/phpunit.junit.xml
+PHPUNIT_COVERAGE_HTML = XDEBUG_MODE=coverage $(PHPUNIT) --coverage-html=$(COVERAGE_HTML)
 INFECTION_BIN = vendor/bin/infection
 INFECTION = $(INFECTION_BIN) --skip-initial-tests --coverage=$(COVERAGE_DIR) --only-covered --show-mutations --min-msi=$(TARGET_MSI) --min-covered-msi=$(TARGET_MSI) --ansi --threads=max
 
@@ -83,7 +85,7 @@ phpunit_coverage_html: $(PHPUNIT_BIN) vendor
 .PHONY: infection
 infection:	  ## Runs Infection
 infection: $(INFECTION_BIN) $(COVERAGE_DIR) vendor
-	if [ -d $(COVERAGE_DIR)/coverage-xml ]; then $(INFECTION); fi
+	if [ -d $(COVERAGE_XML) ]; then $(INFECTION); fi
 
 .PHONY: validate-package
 validate-package: ## Validates the Composer package
@@ -102,8 +104,7 @@ clear-cache:
 .PHONY: clear-coverage
 clear-coverage:	  ## Clears the coverage reports
 clear-coverage:
-	rm -rf dist/phpunit* || true
-	rm -rf dist/coverage* || true
+	rm -rf $(COVERAGE_DIR) || true
 
 
 #
@@ -112,25 +113,25 @@ clear-coverage:
 
 composer.lock: composer.json
 	composer install
-	touch $@
+	touch -c $@
 
 vendor: composer.lock
 	composer install
-	touch $@
+	touch -c $@
 
 $(PHP_CS_FIXER_BIN): vendor
 	composer bin php-cs-fixer install
-	touch $@
+	touch -c $@
 
 $(PHPSTAN_BIN): vendor
-	touch $@
+	touch -c $@
 
 $(PHPUNIT_BIN): vendor
-	touch $@
+	touch -c $@
 
 $(COVERAGE_DIR): $(PHPUNIT_BIN) src tests phpunit.xml.dist
 	$(MAKE) phpunit_coverage_infection
-	$(TOUCH) "$@"
+	touch -c "$@"
 
 $(INFECTION_BIN): vendor
-	touch $@
+	touch -c $@

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-json": "*",
         "bamarni/composer-bin-plugin": "^1.8",
         "ergebnis/composer-normalize": "^2.28",
+        "infection/infection": "^0.26.6",
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.0",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0"
@@ -42,7 +43,9 @@
     "config": {
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true,
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "phpstan/extension-installer": true,
+            "infection/extension-installer": true
         },
         "bamarni-bin": {
             "bin-links": false,

--- a/infection.json
+++ b/infection.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "dist/infection.log"
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,8 +5,8 @@
          beStrictAboutChangesToGlobalState="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutResourceUsageDuringSmallTests="true"
-         beStrictAboutCoversAnnotation="true"
-         colors="true">
+         colors="true"
+         executionOrder="random">
 
     <testsuites>
         <testsuite name="Test Suite">
@@ -15,9 +15,9 @@
     </testsuites>
 
     <coverage>
-        <exclude>
-            <directory suffix=".php">src/</directory>
-        </exclude>
+        <include>
+            <directory>src</directory>
+        </include>
     </coverage>
 
 </phpunit>


### PR DESCRIPTION
- Adds Infection
- Fix the coverage configuration of PHPUnit
- Make PHPUnit tests executed in random order to align with how Infection runs the tests
- Use `touch -c` instead of `touch` as a safeguard
- Add Infection to the pipeline
- Add makefile commands to run PHPUnit with XML (for infection) & HTML coverage
- Add makefime commands to clean up generated artifacts
- Disable fast failure in the CI