### PR TITLE
Simplify the passed environment variables

### DIFF
--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -80,9 +80,9 @@ final class ParallelExecutor
     private string $workingDirectory;
 
     /**
-     * @var array<string, string>
+     * @var array<string, string>|null
      */
-    private array $environmentVariables;
+    private ?array $extraEnvironmentVariables;
 
     private InputDefinition $commandDefinition;
 
@@ -103,7 +103,7 @@ final class ParallelExecutor
      * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
      * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
      * @param callable(int):string                                         $getItemName
-     * @param array<string, string>                                        $environmentVariables
+     * @param array<string, string>                                        $extraEnvironmentVariables
      */
     public function __construct(
         string $progressSymbol,
@@ -120,7 +120,7 @@ final class ParallelExecutor
         string $phpExecutable,
         string $commandName,
         string $workingDirectory,
-        array $environmentVariables,
+        ?array $extraEnvironmentVariables,
         InputDefinition $commandDefinition,
         ItemProcessingErrorHandler $errorHandler
     ) {
@@ -137,7 +137,7 @@ final class ParallelExecutor
         $this->phpExecutable = $phpExecutable;
         $this->commandName = $commandName;
         $this->workingDirectory = $workingDirectory;
-        $this->environmentVariables = $environmentVariables;
+        $this->extraEnvironmentVariables = $extraEnvironmentVariables;
         $this->commandDefinition = $commandDefinition;
         $this->getItemName = $getItemName;
         $this->errorHandler = $errorHandler;
@@ -270,7 +270,7 @@ final class ParallelExecutor
             $processLauncher = new ProcessLauncher(
                 $commandTemplate,
                 $this->workingDirectory,
-                $this->environmentVariables,
+                $this->extraEnvironmentVariables,
                 $numberOfProcesses,
                 $segmentSize,
                 $logger,

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -131,20 +131,14 @@ trait Parallelization
     abstract protected function getItemName(int $count): string;
 
     /**
-     * Returns the environment variables that are passed to the child processes.
+     * Returns the extra environment variables that are passed to the child
+     * processes.
      *
-     * @param ContainerInterface $container The service containers
-     *
-     * @return string[] A list of environment variable names and values
+     * @return array<string, string> a hashmap of environment variable names and values
      */
-    protected function getEnvironmentVariables(ContainerInterface $container): array
+    protected function getExtraEnvironmentVariables(): ?array
     {
-        return [
-            'PATH' => getenv('PATH'),
-            'HOME' => getenv('HOME'),
-            'SYMFONY_DEBUG' => $container->getParameter('kernel.debug'),
-            'SYMFONY_ENV' => $container->getParameter('kernel.environment'),
-        ];
+        return null;
     }
 
     /**
@@ -239,7 +233,7 @@ trait Parallelization
             self::detectPhpExecutable(),
             $this->getName(),
             self::getWorkingDirectory($container),
-            $this->getEnvironmentVariables($container),
+            $this->getExtraEnvironmentVariables(),
             $this->getDefinition(),
             $this->createItemErrorHandler(),
         ))->execute(

--- a/src/ProcessLauncher.php
+++ b/src/ProcessLauncher.php
@@ -36,9 +36,9 @@ class ProcessLauncher
     private string $workingDirectory;
 
     /**
-     * @var array<string, string>
+     * @var array<string, string>|null
      */
-    private array $environmentVariables;
+    private ?array $environmentVariables;
 
     /**
      * @var positive-int
@@ -60,15 +60,15 @@ class ProcessLauncher
     private array $runningProcesses = [];
 
     /**
-     * @param list<string>          $command
-     * @param array<string, string> $environmentVariables
-     * @param positive-int          $numberOfProcesses
-     * @param positive-int          $segmentSize
+     * @param list<string>               $command
+     * @param array<string, string>|null $extraEnvironmentVariables
+     * @param positive-int               $numberOfProcesses
+     * @param positive-int               $segmentSize
      */
     public function __construct(
         array $command,
         string $workingDirectory,
-        array $environmentVariables,
+        ?array $extraEnvironmentVariables,
         int $numberOfProcesses,
         int $segmentSize,
         Logger $logger,
@@ -76,7 +76,7 @@ class ProcessLauncher
     ) {
         $this->command = $command;
         $this->workingDirectory = $workingDirectory;
-        $this->environmentVariables = $environmentVariables;
+        $this->environmentVariables = $extraEnvironmentVariables;
         $this->numberOfProcesses = $numberOfProcesses;
         $this->segmentSize = $segmentSize;
         $this->logger = $logger;


### PR DESCRIPTION
Historically we had those environment variables because they were needed for the child process to behave correctly. As of #28, this is no longer needed.

It is still a nice extension point to have, but at the very least we no longer need to give it the container as we currently do.

For this reason, in this PR:

- Remove the required `ContainerInterface` from the `getEnvironmentVariables()` method
- Rename `getEnvironmentVariables()` to `getExtraEnvironmentVariables()` to better convey that they are not the only environment variables passed down
- Change the default list of environment variables passed to `null`. In practice there is no difference with `[]`, but the code path followed is slightly simpler when `null` is given.