### PR TITLE
Remove dependency on the container to get the current path

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -232,7 +232,7 @@ trait Parallelization
             $this->getConsolePath(),
             self::detectPhpExecutable(),
             $this->getName(),
-            self::getWorkingDirectory($container),
+            self::getWorkingDirectory(),
             $this->getExtraEnvironmentVariables(),
             $this->getDefinition(),
             $this->createItemErrorHandler(),
@@ -341,13 +341,9 @@ trait Parallelization
 
     /**
      * Returns the working directory for the child process.
-     *
-     * @param ContainerInterface $container The service container
-     *
-     * @return string The absolute path to the working directory
      */
-    private static function getWorkingDirectory(ContainerInterface $container): string
+    private static function getWorkingDirectory(): string
     {
-        return dirname($container->getParameter('kernel.project_dir'));
+        return getcwd();
     }
 }

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -215,7 +215,6 @@ trait Parallelization
     {
         $parallelizationInput = ParallelizationInput::fromInput($input);
 
-        $container = $this->getContainer();
         $logger = $this->createLogger($output);
 
         return (new ParallelExecutor(


### PR DESCRIPTION
Since the path to the script entry point (usually `bin/console`) is absolute, it is no longer necessary to launch the command from a specific working directory, although it is probably best to preserve the current one.