### PR TITLE
Rename PHP executable finder

### DIFF
--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -15,7 +15,6 @@ namespace Webmozarts\Console\Parallelization;
 
 use function getcwd;
 use function realpath;
-use RuntimeException;
 use function sprintf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,8 +22,6 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Process\PhpExecutableFinder;
-use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandlerLogger;
@@ -32,6 +29,7 @@ use Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorHandler;
 use Webmozarts\Console\Parallelization\Logger\DebugProgressBarFactory;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 use Webmozarts\Console\Parallelization\Logger\StandardLogger;
+use Webmozarts\Console\Parallelization\Process\PhpExecutableFinder;
 
 /**
  * Adds parallelization capabilities to console commands.
@@ -229,9 +227,9 @@ trait Parallelization
             fn (string $item, InputInterface $input, OutputInterface $output) => $this->runSingleCommand($item, $input, $output),
             fn (int $count) => $this->getItemName($count),
             $this->getConsolePath(),
-            self::detectPhpExecutable(),
+            $this->getPhpExecutable(),
             $this->getName(),
-            self::getWorkingDirectory(),
+            $this->getWorkingDirectory(),
             $this->getExtraEnvironmentVariables(),
             $this->getDefinition(),
             $this->createItemErrorHandler(),
@@ -325,23 +323,17 @@ trait Parallelization
     }
 
     /**
-     * Detects the path of the PHP interpreter.
+     * Returns the path of the PHP executable.
      */
-    private static function detectPhpExecutable(): string
+    private function getPhpExecutable(): string
     {
-        $php = (new PhpExecutableFinder())->find();
-
-        if (false === $php) {
-            throw new RuntimeException('Cannot find php executable');
-        }
-
-        return $php;
+        return PhpExecutableFinder::find();
     }
 
     /**
      * Returns the working directory for the child process.
      */
-    private static function getWorkingDirectory(): string
+    private function getWorkingDirectory(): string
     {
         return getcwd();
     }

--- a/src/Process/PhpExecutableFinder.php
+++ b/src/Process/PhpExecutableFinder.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Process;
+
+use Symfony\Component\Process\PhpExecutableFinder as SymfonyPhpExecutableFinder;
+use Webmozart\Assert\Assert;
+
+final class PhpExecutableFinder
+{
+    private static SymfonyPhpExecutableFinder $finder;
+
+    private function __construct()
+    {
+    }
+
+    public static function find(): string
+    {
+        $phpExecutable = self::getFinder()->find();
+
+        Assert::notFalse(
+            $phpExecutable,
+            'Could not find the PHP executable.',
+        );
+
+        return $phpExecutable;
+    }
+
+    private static function getFinder(): SymfonyPhpExecutableFinder
+    {
+        if (!isset(self::$finder)) {
+            self::$finder = new SymfonyPhpExecutableFinder();
+        }
+
+        return self::$finder;
+    }
+}


### PR DESCRIPTION
- Rename the PHP executable finder from `detectPhpExecutable()` to `getPhpExecutable()` as the act of detecting it is an implementation detail, one could specify directly the desired executable.
- Make `getPhpExecutable()` non static. A user could for example want to get a specific path from the container in which case having access to an instance state is necessary.