### PR TITLE
Rework the console path

### DIFF
--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -17,16 +17,13 @@ use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_slice;
-use function getcwd;
 use function implode;
-use function sprintf;
 use const STDIN;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use function trim;
-use Webmozart\Assert\Assert;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 
@@ -74,7 +71,7 @@ final class ParallelExecutor
      */
     private $runSingleCommand;
 
-    private ?string $consolePath;
+    private string $scriptPath;
     private string $phpExecutable;
     private string $commandName;
     private string $workingDirectory;
@@ -116,7 +113,7 @@ final class ParallelExecutor
         callable $runAfterBatch,
         callable $runSingleCommand,
         callable $getItemName,
-        ?string $consolePath,
+        string $scriptPath,
         string $phpExecutable,
         string $commandName,
         string $workingDirectory,
@@ -133,7 +130,7 @@ final class ParallelExecutor
         $this->runAfterBatch = $runAfterBatch;
         $this->runSingleCommand = $runSingleCommand;
         $this->segmentSize = $segmentSize;
-        $this->consolePath = $consolePath;
+        $this->scriptPath = $scriptPath;
         $this->phpExecutable = $phpExecutable;
         $this->commandName = $commandName;
         $this->workingDirectory = $workingDirectory;
@@ -237,16 +234,10 @@ final class ParallelExecutor
             }
         } else {
             // Distribute if we have multiple segments
-            $consolePath = $this->consolePath;
-            Assert::fileExists(
-                $consolePath,
-                sprintf('The bin/console file could not be found at %s.', getcwd()),
-            );
-
             $commandTemplate = array_merge(
                 array_filter([
                     $this->phpExecutable,
-                    $consolePath,
+                    $this->scriptPath,
                     $this->commandName,
                     implode(
                         ' ',

--- a/tests/Fixtures/Command/ImportMoviesCommand.php
+++ b/tests/Fixtures/Command/ImportMoviesCommand.php
@@ -122,6 +122,11 @@ final class ImportMoviesCommand extends ContainerAwareCommand
         );
     }
 
+    protected function getScriptPath(): string
+    {
+        return __DIR__.'/../../../bin/console';
+    }
+
     /**
      * @param list<string> $movieFileNames
      *

--- a/tests/Fixtures/Command/NoSubProcessCommand.php
+++ b/tests/Fixtures/Command/NoSubProcessCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Fixtures\Command;
 
 use DomainException;
+use function realpath;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -82,5 +83,10 @@ final class NoSubProcessCommand extends ContainerAwareCommand
             new TestDebugProgressBarFactory(),
             new ConsoleLogger($output),
         );
+    }
+
+    protected function getScriptPath(): string
+    {
+        return realpath(__DIR__.'/../../../bin/console');
     }
 }

--- a/tests/Integration/ParallelizationIntegrationTest.php
+++ b/tests/Integration/ParallelizationIntegrationTest.php
@@ -152,24 +152,6 @@ class ParallelizationIntegrationTest extends TestCase
 
             EOF;
 
-        $expected = <<<'EOF'
-            Processing 5 movies in segments of 2, batches of 2, 3 rounds, 3 batches in 2 processes
-
-             0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB[debug] Command started: '/path/to/php' '/path/to/work-dir/bin/console' 'import:movies' '--child' '--env=dev'
-            [debug] Command started: '/path/to/php' '/path/to/work-dir/bin/console' 'import:movies' '--child' '--env=dev'
-            
-             2/5 [===========>----------------]  40% 10 secs/10 secs 10.0 MiB[debug] Command finished
-            [debug] Command started: '/path/to/php' '/path/to/work-dir/bin/console' 'import:movies' '--child' '--env=dev'
-            
-             4/5 [======================>-----]  80% 10 secs/10 secs 10.0 MiB[debug] Command finished
-            
-             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB[debug] Command finished
-
-
-            Processed 5 movies.
-
-            EOF;
-
         $actual = $this->getOutput($commandTester);
 
         $expectedChildProcessesCount = 3;
@@ -217,9 +199,20 @@ class ParallelizationIntegrationTest extends TestCase
             getcwd() => '/path/to/work-dir',
         ];
 
+        $output = self::normalizeConsolePath($output);
+
         return str_replace(
             array_keys($replaceMap),
             $replaceMap,
+            $output,
+        );
+    }
+
+    private static function normalizeConsolePath(string $output): string
+    {
+        return preg_replace(
+            '~'.getcwd().'.+?console~',
+            '/path/to/work-dir/bin/console',
             $output,
         );
     }


### PR DESCRIPTION
Outside of a Symfony app the bin/console path does not make sense. Most of the time however, the script path remains unchanged between the main and child processes so we can make use of that instead.

This change means however that during the tests script path is no longer valid (it is a problem only for child processes) but this can easily be solved by explicitly declaring the script path.

Besides this change:

- Rename the `getConsolePath()` to `getScriptPath()` which is a more generic name which is more fitting when working outside of a Symfony app
- Move the validation of the script path outside of `ParallelExecutor`