### PR TITLE
Introduce the ParallelExecutorFactory

### DIFF
--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -29,8 +29,6 @@ use Webmozarts\Console\Parallelization\Logger\Logger;
 
 final class ParallelExecutor
 {
-    private string $progressSymbol;
-
     /**
      * @var positive-int
      */
@@ -45,6 +43,22 @@ final class ParallelExecutor
      * @var callable(InputInterface):list<string>
      */
     private $fetchItems;
+
+    /**
+     * @var callable(string, InputInterface, OutputInterface):void
+     */
+    private $runSingleCommand;
+
+    /**
+     * @var callable(int): string
+     */
+    private $getItemName;
+
+    private string $commandName;
+
+    private InputDefinition $commandDefinition;
+
+    private ItemProcessingErrorHandler $errorHandler;
 
     /**
      * @var callable(InputInterface, OutputInterface):void
@@ -66,29 +80,13 @@ final class ParallelExecutor
      */
     private $runAfterBatch;
 
-    /**
-     * @var callable(string, InputInterface, OutputInterface):void
-     */
-    private $runSingleCommand;
+    private string $progressSymbol;
+
+    private string $phpExecutable;
 
     private string $scriptPath;
-    private string $phpExecutable;
-    private string $commandName;
+
     private string $workingDirectory;
-
-    /**
-     * @var array<string, string>|null
-     */
-    private ?array $extraEnvironmentVariables;
-
-    private InputDefinition $commandDefinition;
-
-    /**
-     * @var callable(int): string
-     */
-    private $getItemName;
-
-    private ItemProcessingErrorHandler $errorHandler;
 
     /**
      * @param positive-int                                                 $batchSize
@@ -103,23 +101,23 @@ final class ParallelExecutor
      * @param array<string, string>                                        $extraEnvironmentVariables
      */
     public function __construct(
-        string $progressSymbol,
         int $batchSize,
         int $segmentSize,
         callable $fetchItems,
+        callable $runSingleCommand,
+        callable $getItemName,
+        string $commandName,
+        InputDefinition $commandDefinition,
+        ItemProcessingErrorHandler $errorHandler,
         callable $runBeforeFirstCommand,
         callable $runAfterLastCommand,
         callable $runBeforeBatch,
         callable $runAfterBatch,
-        callable $runSingleCommand,
-        callable $getItemName,
+        string $progressSymbol,
         string $scriptPath,
         string $phpExecutable,
-        string $commandName,
         string $workingDirectory,
-        ?array $extraEnvironmentVariables,
-        InputDefinition $commandDefinition,
-        ItemProcessingErrorHandler $errorHandler
+        ?array $extraEnvironmentVariables
     ) {
         $this->progressSymbol = $progressSymbol;
         $this->batchSize = $batchSize;

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -97,15 +97,15 @@ final class ParallelExecutor
     private ?array $extraEnvironmentVariables;
 
     /**
+     * @param callable(InputInterface):list<string>                        $fetchItems
+     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
+     * @param callable(int):string                                         $getItemName
      * @param positive-int                                                 $batchSize
      * @param positive-int                                                 $segmentSize
-     * @param callable(InputInterface):list<string>                        $fetchItems
      * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
      * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
      * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
      * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
-     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
-     * @param callable(int):string                                         $getItemName
      * @param array<string, string>                                        $extraEnvironmentVariables
      */
     public function __construct(
@@ -122,8 +122,8 @@ final class ParallelExecutor
         callable $runBeforeBatch,
         callable $runAfterBatch,
         string $progressSymbol,
-        string $scriptPath,
         string $phpExecutable,
+        string $scriptPath,
         string $workingDirectory,
         ?array $extraEnvironmentVariables
     ) {
@@ -145,8 +145,8 @@ final class ParallelExecutor
         $this->runBeforeBatch = $runBeforeBatch;
         $this->runAfterBatch = $runAfterBatch;
         $this->progressSymbol = $progressSymbol;
-        $this->scriptPath = $scriptPath;
         $this->phpExecutable = $phpExecutable;
+        $this->scriptPath = $scriptPath;
         $this->workingDirectory = $workingDirectory;
         $this->extraEnvironmentVariables = $extraEnvironmentVariables;
     }

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
-use Webmozart\Assert\Assert;
 use function array_filter;
 use function array_map;
 use function array_merge;
@@ -27,6 +26,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use function trim;
+use Webmozart\Assert\Assert;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 

--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -1,30 +1,29 @@
 <?php
 
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
+use function chr;
+use const DIRECTORY_SEPARATOR;
+use function getcwd;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\Process\PhpExecutableFinder;
-use function chr;
-use function getcwd;
-use const DIRECTORY_SEPARATOR;
 
 final class ParallelExecutorFactory
 {
-    /**
-     * @var positive-int
-     */
-    private int $batchSize;
-
-    /**
-     * @var positive-int
-     */
-    private int $segmentSize;
-
     /**
      * @var callable(InputInterface):list<string>
      */
@@ -45,6 +44,16 @@ final class ParallelExecutorFactory
     private InputDefinition $commandDefinition;
 
     private ItemProcessingErrorHandler $errorHandler;
+
+    /**
+     * @var positive-int
+     */
+    private int $batchSize;
+
+    /**
+     * @var positive-int
+     */
+    private int $segmentSize;
 
     /**
      * @var callable(InputInterface, OutputInterface):void
@@ -91,26 +100,66 @@ final class ParallelExecutorFactory
      * @param callable(int):string                                         $getItemName
      * @param array<string, string>                                        $extraEnvironmentVariables
      */
-    public static function create(
+    private function __construct(
+        callable $fetchItems,
+        callable $runSingleCommand,
+        callable $getItemName,
+        string $commandName,
+        InputDefinition $commandDefinition,
+        ItemProcessingErrorHandler $errorHandler,
         int $batchSize,
         int $segmentSize,
+        callable $runBeforeFirstCommand,
+        callable $runAfterLastCommand,
+        callable $runBeforeBatch,
+        callable $runAfterBatch,
+        string $progressSymbol,
+        string $scriptPath,
+        string $phpExecutable,
+        string $workingDirectory,
+        ?array $extraEnvironmentVariables
+    ) {
+        $this->fetchItems = $fetchItems;
+        $this->runSingleCommand = $runSingleCommand;
+        $this->getItemName = $getItemName;
+        $this->commandName = $commandName;
+        $this->commandDefinition = $commandDefinition;
+        $this->errorHandler = $errorHandler;
+        $this->batchSize = $batchSize;
+        $this->segmentSize = $segmentSize;
+        $this->runBeforeFirstCommand = $runBeforeFirstCommand;
+        $this->runAfterLastCommand = $runAfterLastCommand;
+        $this->runBeforeBatch = $runBeforeBatch;
+        $this->runAfterBatch = $runAfterBatch;
+        $this->progressSymbol = $progressSymbol;
+        $this->scriptPath = $scriptPath;
+        $this->phpExecutable = $phpExecutable;
+        $this->workingDirectory = $workingDirectory;
+        $this->extraEnvironmentVariables = $extraEnvironmentVariables;
+    }
+
+    /**
+     * @param callable(InputInterface):list<string>                  $fetchItems
+     * @param callable(string, InputInterface, OutputInterface):void $runSingleCommand
+     * @param callable(int):string                                   $getItemName
+     */
+    public static function create(
         callable $fetchItems,
         callable $runSingleCommand,
         callable $getItemName,
         string $commandName,
         InputDefinition $commandDefinition,
         ItemProcessingErrorHandler $errorHandler
-    ): self
-    {
+    ): self {
         return new self(
-            $batchSize,
-            $segmentSize,
             $fetchItems,
             $runSingleCommand,
             $getItemName,
             $commandName,
             $commandDefinition,
             $errorHandler,
+            50,
+            50,
             self::getNoopCallable(),
             self::getNoopCallable(),
             self::getNoopCallable(),
@@ -120,6 +169,180 @@ final class ParallelExecutorFactory
             self::getPhpExecutable(),
             self::getWorkingDirectory(),
             null,
+        );
+    }
+
+    /**
+     * The number of items to process in a batch. Multiple batches can be
+     * executed within the main and child processes. This allows to early fetch
+     * aggregates or persist aggregates in batches for performance optimizations
+     * for example.
+     *
+     * @param positive-int $batchSize
+     */
+    public function withBatchSize(int $batchSize): self
+    {
+        $clone = clone $this;
+        $clone->batchSize = $batchSize;
+
+        return $clone;
+    }
+
+    /**
+     * The number of items to process per child process. This is done in order
+     * to circumvent some issues recurring to long living processes such as
+     * memory leaks.
+     *
+     * This value is only relevant when ran with child process(es).
+     *
+     * @param positive-int $segmentSize
+     */
+    public function withSegmentSize(int $segmentSize): self
+    {
+        $clone = clone $this;
+        $clone->segmentSize = $segmentSize;
+
+        return $clone;
+    }
+
+    /**
+     * Callable executed at the very beginning of the main process.
+     *
+     * @param callable(InputInterface, OutputInterface):void $runBeforeFirstCommand
+     */
+    public function withRunBeforeFirstCommand(callable $runBeforeFirstCommand): self
+    {
+        $clone = clone $this;
+        $clone->runBeforeFirstCommand = $runBeforeFirstCommand;
+
+        return $clone;
+    }
+
+    /**
+     * Callable executed at the very end of the main process.
+     *
+     * @param callable(InputInterface, OutputInterface):void $runAfterLastCommand
+     */
+    public function withRunAfterLastCommand(callable $runAfterLastCommand): self
+    {
+        $clone = clone $this;
+        $clone->runAfterLastCommand = $runAfterLastCommand;
+
+        return $clone;
+    }
+
+    /**
+     * Callable executed before executing all the items of the current batch. It
+     * is executed in either the main or child process depending on whether
+     * child processes are spawned.
+     *
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
+     */
+    public function withRunBeforeBatch(callable $runBeforeBatch): self
+    {
+        $clone = clone $this;
+        $clone->runBeforeBatch = $runBeforeBatch;
+
+        return $clone;
+    }
+
+    /**
+     * Callable executed after executing all the items of the current batch. It
+     * is executed in either the main or child process depending on whether
+     * child processes are spawned.
+     *
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
+     */
+    public function withRunAfterBatch(callable $runAfterBatch): self
+    {
+        $clone = clone $this;
+        $clone->runAfterBatch = $runAfterBatch;
+
+        return $clone;
+    }
+
+    /**
+     * The symbol for communicating progress from the child to the main process
+     * when displaying the progress bar.
+     */
+    public function withProgressSymbol(string $progressSymbol): self
+    {
+        $clone = clone $this;
+        $clone->runAfterBatch = $progressSymbol;
+
+        return $clone;
+    }
+
+    /**
+     * The path of the executable for the application. For example the path to
+     * the Symfony bin/console script. It is the script that will be used to
+     * spawn the child process(es).
+     */
+    public function withScriptPath(string $scriptPath): self
+    {
+        $clone = clone $this;
+        $clone->scriptPath = $scriptPath;
+
+        return $clone;
+    }
+
+    /**
+     * The path of the PHP executable. It is the executable that will be used
+     * to spawn the child process(es).
+     */
+    public function withPhpExecutable(string $phpExecutable): self
+    {
+        $clone = clone $this;
+        $clone->phpExecutable = $phpExecutable;
+
+        return $clone;
+    }
+
+    /**
+     * The working directory for the child process(es).
+     */
+    public function withWorkingDirectory(string $workingDirectory): self
+    {
+        $clone = clone $this;
+        $clone->workingDirectory = $workingDirectory;
+
+        return $clone;
+    }
+
+    /**
+     * Configure the extra environment variables that are passed to the child
+     * processes.
+     *
+     * @param array<string, string> $extraEnvironmentVariables
+     */
+    public function withExtraEnvironmentVariables(?array $extraEnvironmentVariables): self
+    {
+        $clone = clone $this;
+        $clone->extraEnvironmentVariables = $extraEnvironmentVariables;
+
+        return $clone;
+    }
+
+    public function build(): ParallelExecutor
+    {
+        return new ParallelExecutor(
+            $this->fetchItems,
+            $this->runSingleCommand,
+            $this->getItemName,
+            $this->commandName,
+            $this->commandDefinition,
+            $this->errorHandler,
+            $this->batchSize,
+            $this->segmentSize,
+            $this->runBeforeFirstCommand,
+            $this->runAfterLastCommand,
+            $this->runBeforeBatch,
+            $this->runAfterBatch,
+            $this->progressSymbol,
+            $this->scriptPath,
+            $this->phpExecutable,
+            $this->workingDirectory,
+            $this->extraEnvironmentVariables,
         );
     }
 
@@ -145,7 +368,7 @@ final class ParallelExecutorFactory
         return $noop;
     }
 
-    private static function getScriptPath(): callable
+    private static function getScriptPath(): string
     {
         static $scriptPath;
 
@@ -161,7 +384,7 @@ final class ParallelExecutorFactory
         return $scriptPath;
     }
 
-    private static function getPhpExecutable(): callable
+    private static function getPhpExecutable(): string
     {
         static $phpExecutable;
 
@@ -172,7 +395,7 @@ final class ParallelExecutorFactory
         return $phpExecutable;
     }
 
-    private static function getWorkingDirectory(): callable
+    private static function getWorkingDirectory(): string
     {
         static $cwd;
 
@@ -181,170 +404,5 @@ final class ParallelExecutorFactory
         }
 
         return $cwd;
-    }
-
-    /**
-     * @param positive-int                                                 $batchSize
-     * @param positive-int                                                 $segmentSize
-     * @param callable(InputInterface):list<string>                        $fetchItems
-     * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
-     * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
-     * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
-     * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
-     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
-     * @param callable(int):string                                         $getItemName
-     * @param array<string, string>                                        $extraEnvironmentVariables
-     */
-    private function __construct(
-        int $batchSize,
-        int $segmentSize,
-        callable $fetchItems,
-        callable $runSingleCommand,
-        callable $getItemName,
-        string $commandName,
-        InputDefinition $commandDefinition,
-        ItemProcessingErrorHandler $errorHandler,
-        callable $runBeforeFirstCommand,
-        callable $runAfterLastCommand,
-        callable $runBeforeBatch,
-        callable $runAfterBatch,
-        string $progressSymbol,
-        string $scriptPath,
-        string $phpExecutable,
-        string $workingDirectory,
-        ?array $extraEnvironmentVariables
-    ) {
-        $this->batchSize = $batchSize;
-        $this->segmentSize = $segmentSize;
-        $this->fetchItems = $fetchItems;
-        $this->runSingleCommand = $runSingleCommand;
-        $this->getItemName = $getItemName;
-        $this->commandName = $commandName;
-        $this->commandDefinition = $commandDefinition;
-        $this->errorHandler = $errorHandler;
-        $this->runBeforeFirstCommand = $runBeforeFirstCommand;
-        $this->runAfterLastCommand = $runAfterLastCommand;
-        $this->runBeforeBatch = $runBeforeBatch;
-        $this->runAfterBatch = $runAfterBatch;
-        $this->progressSymbol = $progressSymbol;
-        $this->scriptPath = $scriptPath;
-        $this->phpExecutable = $phpExecutable;
-        $this->workingDirectory = $workingDirectory;
-        $this->extraEnvironmentVariables = $extraEnvironmentVariables;
-    }
-
-    /**
-     * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
-     */
-    public function withRunBeforeFirstCommand(callable $runBeforeFirstCommand): self
-    {
-        $clone = clone $this;
-        $clone->runBeforeFirstCommand = $runBeforeFirstCommand;
-
-        return $clone;
-    }
-
-    /**
-     * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
-     */
-    public function withRunAfterLastCommand(callable $runAfterLastCommand): self
-    {
-        $clone = clone $this;
-        $clone->runAfterLastCommand = $runAfterLastCommand;
-
-        return $clone;
-    }
-
-    /**
-     * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
-     */
-    public function withRunBeforeBatch(callable $runBeforeBatch): self
-    {
-        $clone = clone $this;
-        $clone->runBeforeBatch = $runBeforeBatch;
-
-        return $clone;
-    }
-
-    /**
-     * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
-     */
-    public function withRunAfterBatch(callable $runAfterBatch): self
-    {
-        $clone = clone $this;
-        $clone->runAfterBatch = $runAfterBatch;
-
-        return $clone;
-    }
-
-    public function withProgressSymbol(string $progressSymbol): self
-    {
-        $clone = clone $this;
-        $clone->runAfterBatch = $progressSymbol;
-
-        return $clone;
-    }
-
-    public function withScriptPath(string $scriptPath): self
-    {
-        $clone = clone $this;
-        $clone->scriptPath = $scriptPath;
-
-        return $clone;
-    }
-
-    public function withPhpExecutable(string $phpExecutable): self
-    {
-        $clone = clone $this;
-        $clone->phpExecutable = $phpExecutable;
-
-        return $clone;
-    }
-
-    public function withWorkingDirectory(string $workingDirectory): self
-    {
-        $clone = clone $this;
-        $clone->workingDirectory = $workingDirectory;
-
-        return $clone;
-    }
-
-    /**
-     * @param array<string, string>                                        $extraEnvironmentVariables
-     */
-    public function withExtraEnvironmentVariables(?array $extraEnvironmentVariables): self
-    {
-        $clone = clone $this;
-        $clone->extraEnvironmentVariables = $extraEnvironmentVariables;
-
-        return $clone;
-    }
-
-    public function build(): ParallelExecutor
-    {
-        // TODO:
-        //  - script path validation
-        //  - symbol validation
-        //  - php executable validation
-        //  - working dir validation
-        return new ParallelExecutor(
-            $this->batchSize,
-            $this->segmentSize,
-            $this->fetchItems,
-            $this->runSingleCommand,
-            $this->getItemName,
-            $this->commandName,
-            $this->commandDefinition,
-            $this->errorHandler,
-            $this->runBeforeFirstCommand,
-            $this->runAfterLastCommand,
-            $this->runBeforeBatch,
-            $this->runAfterBatch,
-            $this->progressSymbol,
-            $this->scriptPath,
-            $this->phpExecutable,
-            $this->workingDirectory,
-            $this->extraEnvironmentVariables,
-        );
     }
 }

--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
+use Webmozarts\Console\Parallelization\Process\PhpExecutableFinder;
+use function chr;
+use function getcwd;
+use const DIRECTORY_SEPARATOR;
+
+final class ParallelExecutorFactory
+{
+    /**
+     * @var positive-int
+     */
+    private int $batchSize;
+
+    /**
+     * @var positive-int
+     */
+    private int $segmentSize;
+
+    /**
+     * @var callable(InputInterface):list<string>
+     */
+    private $fetchItems;
+
+    /**
+     * @var callable(string, InputInterface, OutputInterface):void
+     */
+    private $runSingleCommand;
+
+    /**
+     * @var callable(int): string
+     */
+    private $getItemName;
+
+    private string $commandName;
+
+    private InputDefinition $commandDefinition;
+
+    private ItemProcessingErrorHandler $errorHandler;
+
+    /**
+     * @var callable(InputInterface, OutputInterface):void
+     */
+    private $runBeforeFirstCommand;
+
+    /**
+     * @var callable(InputInterface, OutputInterface):void
+     */
+    private $runAfterLastCommand;
+
+    /**
+     * @var callable(InputInterface, OutputInterface, list<string>):void
+     */
+    private $runBeforeBatch;
+
+    /**
+     * @var callable(InputInterface, OutputInterface, list<string>):void
+     */
+    private $runAfterBatch;
+
+    private string $progressSymbol;
+
+    private string $phpExecutable;
+
+    private string $scriptPath;
+
+    private string $workingDirectory;
+
+    /**
+     * @var array<string, string>|null
+     */
+    private ?array $extraEnvironmentVariables;
+
+    /**
+     * @param positive-int                                                 $batchSize
+     * @param positive-int                                                 $segmentSize
+     * @param callable(InputInterface):list<string>                        $fetchItems
+     * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
+     * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
+     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
+     * @param callable(int):string                                         $getItemName
+     * @param array<string, string>                                        $extraEnvironmentVariables
+     */
+    public static function create(
+        int $batchSize,
+        int $segmentSize,
+        callable $fetchItems,
+        callable $runSingleCommand,
+        callable $getItemName,
+        string $commandName,
+        InputDefinition $commandDefinition,
+        ItemProcessingErrorHandler $errorHandler
+    ): self
+    {
+        return new self(
+            $batchSize,
+            $segmentSize,
+            $fetchItems,
+            $runSingleCommand,
+            $getItemName,
+            $commandName,
+            $commandDefinition,
+            $errorHandler,
+            self::getNoopCallable(),
+            self::getNoopCallable(),
+            self::getNoopCallable(),
+            self::getNoopCallable(),
+            self::getProgressSymbol(),
+            self::getScriptPath(),
+            self::getPhpExecutable(),
+            self::getWorkingDirectory(),
+            null,
+        );
+    }
+
+    private static function getProgressSymbol(): string
+    {
+        static $progressSymbol;
+
+        if (!isset($progressSymbol)) {
+            $progressSymbol = chr(254);
+        }
+
+        return $progressSymbol;
+    }
+
+    private static function getNoopCallable(): callable
+    {
+        static $noop;
+
+        if (!isset($noop)) {
+            $noop = static function () {};
+        }
+
+        return $noop;
+    }
+
+    private static function getScriptPath(): callable
+    {
+        static $scriptPath;
+
+        if (!isset($scriptPath)) {
+            $pwd = $_SERVER['PWD'];
+            $scriptName = $_SERVER['SCRIPT_NAME'];
+
+            $scriptPath = 0 === mb_strpos($scriptName, $pwd)
+                ? $scriptName
+                : $pwd.DIRECTORY_SEPARATOR.$scriptName;
+        }
+
+        return $scriptPath;
+    }
+
+    private static function getPhpExecutable(): callable
+    {
+        static $phpExecutable;
+
+        if (!isset($phpExecutable)) {
+            $phpExecutable = PhpExecutableFinder::find();
+        }
+
+        return $phpExecutable;
+    }
+
+    private static function getWorkingDirectory(): callable
+    {
+        static $cwd;
+
+        if (!isset($cwd)) {
+            $cwd = getcwd();
+        }
+
+        return $cwd;
+    }
+
+    /**
+     * @param positive-int                                                 $batchSize
+     * @param positive-int                                                 $segmentSize
+     * @param callable(InputInterface):list<string>                        $fetchItems
+     * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
+     * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
+     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
+     * @param callable(int):string                                         $getItemName
+     * @param array<string, string>                                        $extraEnvironmentVariables
+     */
+    private function __construct(
+        int $batchSize,
+        int $segmentSize,
+        callable $fetchItems,
+        callable $runSingleCommand,
+        callable $getItemName,
+        string $commandName,
+        InputDefinition $commandDefinition,
+        ItemProcessingErrorHandler $errorHandler,
+        callable $runBeforeFirstCommand,
+        callable $runAfterLastCommand,
+        callable $runBeforeBatch,
+        callable $runAfterBatch,
+        string $progressSymbol,
+        string $scriptPath,
+        string $phpExecutable,
+        string $workingDirectory,
+        ?array $extraEnvironmentVariables
+    ) {
+        $this->batchSize = $batchSize;
+        $this->segmentSize = $segmentSize;
+        $this->fetchItems = $fetchItems;
+        $this->runSingleCommand = $runSingleCommand;
+        $this->getItemName = $getItemName;
+        $this->commandName = $commandName;
+        $this->commandDefinition = $commandDefinition;
+        $this->errorHandler = $errorHandler;
+        $this->runBeforeFirstCommand = $runBeforeFirstCommand;
+        $this->runAfterLastCommand = $runAfterLastCommand;
+        $this->runBeforeBatch = $runBeforeBatch;
+        $this->runAfterBatch = $runAfterBatch;
+        $this->progressSymbol = $progressSymbol;
+        $this->scriptPath = $scriptPath;
+        $this->phpExecutable = $phpExecutable;
+        $this->workingDirectory = $workingDirectory;
+        $this->extraEnvironmentVariables = $extraEnvironmentVariables;
+    }
+
+    /**
+     * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
+     */
+    public function withRunBeforeFirstCommand(callable $runBeforeFirstCommand): self
+    {
+        $clone = clone $this;
+        $clone->runBeforeFirstCommand = $runBeforeFirstCommand;
+
+        return $clone;
+    }
+
+    /**
+     * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
+     */
+    public function withRunAfterLastCommand(callable $runAfterLastCommand): self
+    {
+        $clone = clone $this;
+        $clone->runAfterLastCommand = $runAfterLastCommand;
+
+        return $clone;
+    }
+
+    /**
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
+     */
+    public function withRunBeforeBatch(callable $runBeforeBatch): self
+    {
+        $clone = clone $this;
+        $clone->runBeforeBatch = $runBeforeBatch;
+
+        return $clone;
+    }
+
+    /**
+     * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
+     */
+    public function withRunAfterBatch(callable $runAfterBatch): self
+    {
+        $clone = clone $this;
+        $clone->runAfterBatch = $runAfterBatch;
+
+        return $clone;
+    }
+
+    public function withProgressSymbol(string $progressSymbol): self
+    {
+        $clone = clone $this;
+        $clone->runAfterBatch = $progressSymbol;
+
+        return $clone;
+    }
+
+    public function withScriptPath(string $scriptPath): self
+    {
+        $clone = clone $this;
+        $clone->scriptPath = $scriptPath;
+
+        return $clone;
+    }
+
+    public function withPhpExecutable(string $phpExecutable): self
+    {
+        $clone = clone $this;
+        $clone->phpExecutable = $phpExecutable;
+
+        return $clone;
+    }
+
+    public function withWorkingDirectory(string $workingDirectory): self
+    {
+        $clone = clone $this;
+        $clone->workingDirectory = $workingDirectory;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, string>                                        $extraEnvironmentVariables
+     */
+    public function withExtraEnvironmentVariables(?array $extraEnvironmentVariables): self
+    {
+        $clone = clone $this;
+        $clone->extraEnvironmentVariables = $extraEnvironmentVariables;
+
+        return $clone;
+    }
+
+    public function build(): ParallelExecutor
+    {
+        // TODO:
+        //  - script path validation
+        //  - symbol validation
+        //  - php executable validation
+        //  - working dir validation
+        return new ParallelExecutor(
+            $this->batchSize,
+            $this->segmentSize,
+            $this->fetchItems,
+            $this->runSingleCommand,
+            $this->getItemName,
+            $this->commandName,
+            $this->commandDefinition,
+            $this->errorHandler,
+            $this->runBeforeFirstCommand,
+            $this->runAfterLastCommand,
+            $this->runBeforeBatch,
+            $this->runAfterBatch,
+            $this->progressSymbol,
+            $this->scriptPath,
+            $this->phpExecutable,
+            $this->workingDirectory,
+            $this->extraEnvironmentVariables,
+        );
+    }
+}

--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -75,9 +75,9 @@ final class ParallelExecutorFactory
      */
     private $runAfterBatch;
 
-    private string $progressSymbol;
-
     private string $phpExecutable;
+
+    private string $progressSymbol;
 
     private string $scriptPath;
 
@@ -89,15 +89,15 @@ final class ParallelExecutorFactory
     private ?array $extraEnvironmentVariables;
 
     /**
+     * @param callable(InputInterface):list<string>                        $fetchItems
+     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
+     * @param callable(int):string                                         $getItemName
      * @param positive-int                                                 $batchSize
      * @param positive-int                                                 $segmentSize
-     * @param callable(InputInterface):list<string>                        $fetchItems
      * @param callable(InputInterface, OutputInterface):void               $runBeforeFirstCommand
      * @param callable(InputInterface, OutputInterface):void               $runAfterLastCommand
      * @param callable(InputInterface, OutputInterface, list<string>):void $runBeforeBatch
      * @param callable(InputInterface, OutputInterface, list<string>):void $runAfterBatch
-     * @param callable(string, InputInterface, OutputInterface):void       $runSingleCommand
-     * @param callable(int):string                                         $getItemName
      * @param array<string, string>                                        $extraEnvironmentVariables
      */
     private function __construct(
@@ -114,8 +114,8 @@ final class ParallelExecutorFactory
         callable $runBeforeBatch,
         callable $runAfterBatch,
         string $progressSymbol,
-        string $scriptPath,
         string $phpExecutable,
+        string $scriptPath,
         string $workingDirectory,
         ?array $extraEnvironmentVariables
     ) {
@@ -132,8 +132,8 @@ final class ParallelExecutorFactory
         $this->runBeforeBatch = $runBeforeBatch;
         $this->runAfterBatch = $runAfterBatch;
         $this->progressSymbol = $progressSymbol;
-        $this->scriptPath = $scriptPath;
         $this->phpExecutable = $phpExecutable;
+        $this->scriptPath = $scriptPath;
         $this->workingDirectory = $workingDirectory;
         $this->extraEnvironmentVariables = $extraEnvironmentVariables;
     }
@@ -165,8 +165,8 @@ final class ParallelExecutorFactory
             self::getNoopCallable(),
             self::getNoopCallable(),
             self::getProgressSymbol(),
-            self::getScriptPath(),
             self::getPhpExecutable(),
+            self::getScriptPath(),
             self::getWorkingDirectory(),
             null,
         );
@@ -268,7 +268,19 @@ final class ParallelExecutorFactory
     public function withProgressSymbol(string $progressSymbol): self
     {
         $clone = clone $this;
-        $clone->runAfterBatch = $progressSymbol;
+        $clone->progressSymbol = $progressSymbol;
+
+        return $clone;
+    }
+
+    /**
+     * The path of the PHP executable. It is the executable that will be used
+     * to spawn the child process(es).
+     */
+    public function withPhpExecutable(string $phpExecutable): self
+    {
+        $clone = clone $this;
+        $clone->phpExecutable = $phpExecutable;
 
         return $clone;
     }
@@ -282,18 +294,6 @@ final class ParallelExecutorFactory
     {
         $clone = clone $this;
         $clone->scriptPath = $scriptPath;
-
-        return $clone;
-    }
-
-    /**
-     * The path of the PHP executable. It is the executable that will be used
-     * to spawn the child process(es).
-     */
-    public function withPhpExecutable(string $phpExecutable): self
-    {
-        $clone = clone $this;
-        $clone->phpExecutable = $phpExecutable;
 
         return $clone;
     }
@@ -339,8 +339,8 @@ final class ParallelExecutorFactory
             $this->runBeforeBatch,
             $this->runAfterBatch,
             $this->progressSymbol,
-            $this->scriptPath,
             $this->phpExecutable,
+            $this->scriptPath,
             $this->workingDirectory,
             $this->extraEnvironmentVariables,
         );

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;
 
-use function sprintf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,7 +20,6 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Webmozart\Assert\Assert;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandlerLogger;
 use Webmozarts\Console\Parallelization\ErrorHandler\ResetContainerErrorHandler;

--- a/tests/ErrorHandler/FakeErrorHandler.php
+++ b/tests/ErrorHandler/FakeErrorHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\ErrorHandler;
+
+use DomainException;
+use Throwable;
+use Webmozarts\Console\Parallelization\Logger\Logger;
+
+final class FakeErrorHandler implements ItemProcessingErrorHandler
+{
+    public function handleError(string $item, Throwable $throwable, Logger $logger): void
+    {
+        throw new DomainException('Unexpected call.');
+    }
+}

--- a/tests/Fixtures/Command/ImportMoviesCommand.php
+++ b/tests/Fixtures/Command/ImportMoviesCommand.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\Fixtures\Command;
 
-use Symfony\Component\Console\Input\InputDefinition;
-use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
-use Webmozarts\Console\Parallelization\ParallelExecutorFactory;
 use function file_get_contents;
 use function json_decode;
-use function realpath;
 use const JSON_THROW_ON_ERROR;
+use function realpath;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
 use Webmozarts\Console\Parallelization\ContainerAwareCommand;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\Integration\TestDebugProgressBarFactory;
 use Webmozarts\Console\Parallelization\Integration\TestLogger;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 use Webmozarts\Console\Parallelization\Logger\StandardLogger;
+use Webmozarts\Console\Parallelization\ParallelExecutorFactory;
 use Webmozarts\Console\Parallelization\Parallelization;
 
 final class ImportMoviesCommand extends ContainerAwareCommand
@@ -119,6 +119,16 @@ final class ImportMoviesCommand extends ContainerAwareCommand
         return 1 === $count ? 'movie' : 'movies';
     }
 
+    protected function createLogger(OutputInterface $output): Logger
+    {
+        return new StandardLogger(
+            $output,
+            (new Terminal())->getWidth(),
+            new TestDebugProgressBarFactory(),
+            new ConsoleLogger($output),
+        );
+    }
+
     private function runBeforeBatch(
         array $movieFileNames
     ): void {
@@ -132,16 +142,6 @@ final class ImportMoviesCommand extends ContainerAwareCommand
         $this->logger->recordAfterBatch();
 
         unset($this->batchMovies);
-    }
-
-    protected function createLogger(OutputInterface $output): Logger
-    {
-        return new StandardLogger(
-            $output,
-            (new Terminal())->getWidth(),
-            new TestDebugProgressBarFactory(),
-            new ConsoleLogger($output),
-        );
     }
 
     /**

--- a/tests/Fixtures/Command/NoSubProcessCommand.php
+++ b/tests/Fixtures/Command/NoSubProcessCommand.php
@@ -14,18 +14,18 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Fixtures\Command;
 
 use DomainException;
-use Symfony\Component\Console\Input\InputDefinition;
-use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
-use Webmozarts\Console\Parallelization\ParallelExecutorFactory;
 use function realpath;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
 use Webmozarts\Console\Parallelization\ContainerAwareCommand;
+use Webmozarts\Console\Parallelization\ErrorHandler\ItemProcessingErrorHandler;
 use Webmozarts\Console\Parallelization\Integration\TestDebugProgressBarFactory;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 use Webmozarts\Console\Parallelization\Logger\StandardLogger;
+use Webmozarts\Console\Parallelization\ParallelExecutorFactory;
 use Webmozarts\Console\Parallelization\Parallelization;
 
 final class NoSubProcessCommand extends ContainerAwareCommand
@@ -77,7 +77,9 @@ final class NoSubProcessCommand extends ContainerAwareCommand
             ->withBatchSize(2)
             ->withSegmentSize(2)
             ->withRunBeforeFirstCommand(
-                fn () => $this->mainProcess = true,
+                function () {
+                    $this->mainProcess = true;
+                },
             )
             ->withScriptPath(realpath(__DIR__.'/../../../bin/console'));
     }

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+use Webmozarts\Console\Parallelization\ErrorHandler\FakeErrorHandler;
+
+/**
+ * @covers \Webmozarts\Console\Parallelization\ParallelExecutorFactory
+ */
+final class ParallelExecutorFactoryTest extends TestCase
+{
+    private const FILE_1 = __DIR__;
+    private const FILE_2 = __DIR__.'/Logger/FakeLogger.php';
+    private const FILE_3 = __DIR__.'/ErrorHandler/FakeErrorHandler.php';
+
+    public function test_it_can_create_a_configured_executor(): void
+    {
+        $commandName = 'import:items';
+        $definition = new InputDefinition();
+        $errorHandler = new FakeErrorHandler();
+
+        $callable0 = self::createCallable(0);
+        $callable1 = self::createCallable(1);
+        $callable2 = self::createCallable(2);
+        $callable3 = self::createCallable(3);
+        $callable4 = self::createCallable(4);
+        $callable5 = self::createCallable(5);
+        $callable6 = self::createCallable(6);
+
+        $batchSize = 10;
+        $segmentSize = 20;
+        $extraEnvironmentVariables = ['CUSTOM_CI' => '0'];
+        $progressSymbol = 'ø';
+
+        $executor = ParallelExecutorFactory::create(
+            $callable0,
+            $callable1,
+            $callable2,
+            $commandName,
+            $definition,
+            $errorHandler,
+        )
+            ->withBatchSize($batchSize)
+            ->withSegmentSize($segmentSize)
+            ->withRunBeforeFirstCommand($callable3)
+            ->withRunAfterLastCommand($callable4)
+            ->withRunBeforeBatch($callable5)
+            ->withRunAfterBatch($callable6)
+            ->withProgressSymbol($progressSymbol)
+            ->withPhpExecutable(self::FILE_1)
+            ->withScriptPath(self::FILE_2)
+            ->withWorkingDirectory(self::FILE_3)
+            ->withExtraEnvironmentVariables($extraEnvironmentVariables)
+            ->build();
+
+        $expected = new ParallelExecutor(
+            $callable0,
+            $callable1,
+            $callable2,
+            $commandName,
+            $definition,
+            $errorHandler,
+            $batchSize,
+            $segmentSize,
+            $callable3,
+            $callable4,
+            $callable5,
+            $callable6,
+            $progressSymbol,
+            self::FILE_1,
+            self::FILE_2,
+            self::FILE_3,
+            $extraEnvironmentVariables,
+        );
+
+        self::assertEquals($expected, $executor);
+    }
+
+    private static function createCallable(int $id): callable
+    {
+        return static function () use ($id): void {
+            echo $id;
+        };
+    }
+}


### PR DESCRIPTION
This PR introduces the biggest piece that will allow to make it a lot easier to port the core of the trait to a regular command.

The `ParallelExecutorFactory` allows to create a `ParallelExecutor` with minimal code (i.e. leveraging the default values as much as possible) whilst still allowing the user to easily override any parameter.