### PR TITLE
Pass progress symbol as a parameter instead of part of the constructor

### DIFF
--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -33,7 +33,7 @@ interface Logger
 
     public function finish(string $itemName): void;
 
-    public function logUnexpectedOutput(string $buffer): void;
+    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void;
 
     public function logCommandStarted(string $commandName): void;
 

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -26,7 +26,6 @@ use Webmozart\Assert\Assert;
 final class StandardLogger implements Logger
 {
     private OutputInterface $output;
-    private string $advancementChar;
     private int $terminalWidth;
     private ProgressBar $progressBar;
     private ProgressBarFactory $progressBarFactory;
@@ -34,13 +33,11 @@ final class StandardLogger implements Logger
 
     public function __construct(
         OutputInterface $output,
-        string $advancementCharacter,
         int $terminalWidth,
         ProgressBarFactory $progressBarFactory,
         LoggerInterface $logger
     ) {
         $this->output = $output;
-        $this->advancementChar = $advancementCharacter;
         $this->terminalWidth = $terminalWidth;
         $this->progressBarFactory = $progressBarFactory;
         $this->logger = $logger;
@@ -115,7 +112,7 @@ final class StandardLogger implements Logger
         unset($this->progressBar);
     }
 
-    public function logUnexpectedOutput(string $buffer): void
+    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
     {
         $this->output->writeln('');
         $this->output->writeln(sprintf(
@@ -127,7 +124,7 @@ final class StandardLogger implements Logger
                 STR_PAD_BOTH,
             ),
         ));
-        $this->output->writeln(str_replace($this->advancementChar, '', $buffer));
+        $this->output->writeln(str_replace($progressSymbol, '', $buffer));
         $this->output->writeln('');
     }
 

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -330,12 +330,12 @@ final class ParallelExecutor
         string $buffer,
         Logger $logger
     ): void {
-        $advancementChar = $this->progressSymbol;
-        $chars = mb_substr_count($buffer, $advancementChar);
+        $progressSymbol = $this->progressSymbol;
+        $chars = mb_substr_count($buffer, $progressSymbol);
 
         // Display unexpected output
         if ($chars !== mb_strlen($buffer)) {
-            $logger->logUnexpectedOutput($buffer);
+            $logger->logUnexpectedOutput($buffer, $progressSymbol);
         }
 
         $logger->advance($chars);

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -259,7 +259,6 @@ trait Parallelization
     {
         return new StandardLogger(
             $output,
-            self::getProgressSymbol(),
             (new Terminal())->getWidth(),
             new DebugProgressBarFactory(),
             new ConsoleLogger($output),

--- a/tests/Fixtures/Command/ImportMoviesCommand.php
+++ b/tests/Fixtures/Command/ImportMoviesCommand.php
@@ -115,7 +115,6 @@ final class ImportMoviesCommand extends ContainerAwareCommand
     {
         return new StandardLogger(
             $output,
-            self::getProgressSymbol(),
             (new Terminal())->getWidth(),
             new TestDebugProgressBarFactory(),
             new ConsoleLogger($output),

--- a/tests/Fixtures/Command/NoSubProcessCommand.php
+++ b/tests/Fixtures/Command/NoSubProcessCommand.php
@@ -78,7 +78,6 @@ final class NoSubProcessCommand extends ContainerAwareCommand
     {
         return new StandardLogger(
             $output,
-            self::getProgressSymbol(),
             (new Terminal())->getWidth(),
             new TestDebugProgressBarFactory(),
             new ConsoleLogger($output),

--- a/tests/Logger/FakeLogger.php
+++ b/tests/Logger/FakeLogger.php
@@ -45,7 +45,7 @@ final class FakeLogger implements Logger
         throw new DomainException('Unexpected call.');
     }
 
-    public function logUnexpectedOutput(string $buffer): void
+    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
     {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -36,7 +36,6 @@ final class StandardLoggerTest extends TestCase
 
         $this->logger = new StandardLogger(
             $this->output,
-            self::ADVANCEMENT_CHARACTER,
             self::TERMINAL_WIDTH,
             new TestProgressBarFactory(),
             new ConsoleLogger($this->output),
@@ -129,7 +128,32 @@ final class StandardLoggerTest extends TestCase
         $this->logger->advance(4);
         $this->output->fetch();
 
-        $this->logger->logUnexpectedOutput('An error occurred.');
+        $this->logger->logUnexpectedOutput(
+            'An error occurred.',
+            self::ADVANCEMENT_CHARACTER,
+        );
+
+        $expected = <<<'TXT'
+            
+            ================= Process Output =================
+            An error occurred.
+
+
+            TXT;
+
+        self::assertSame($expected, $this->output->fetch());
+    }
+
+    public function test_it_removes_the_progress_character_of_the_unexpected_output_of_a_child_process(): void
+    {
+        $this->logger->startProgress(10);
+        $this->logger->advance(4);
+        $this->output->fetch();
+
+        $this->logger->logUnexpectedOutput(
+            'An error'.self::ADVANCEMENT_CHARACTER.' occurred.',
+            self::ADVANCEMENT_CHARACTER,
+        );
 
         $expected = <<<'TXT'
             


### PR DESCRIPTION
This offers more flexibility as it makes the instantiation of the standard logger no longer dependent of the progress symbol. This means if we remove the progress symbol from being passed to the parallel executor (for example to use a default value), this will not be a problem (currently that default value _needs_ to be in Parallelization).