### PR TITLE
Introduce a ProcessLauncherFactory

### DIFF
--- a/src/Process/ProcessLauncher.php
+++ b/src/Process/ProcessLauncher.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Process;
+
+interface ProcessLauncher
+{
+    /**
+     * Runs child processes to process the given items.
+     *
+     * @param list<string> $items The items to process. None of the items must
+     *                            contain newlines
+     */
+    public function run(array $items): void;
+}

--- a/src/Process/ProcessLauncherFactory.php
+++ b/src/Process/ProcessLauncherFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Process;
+
+use Closure;
+use Webmozarts\Console\Parallelization\Logger\Logger;
+
+interface ProcessLauncherFactory
+{
+    /**
+     * @param list<string>               $command
+     * @param array<string, string>|null $extraEnvironmentVariables
+     * @param positive-int               $numberOfProcesses
+     * @param positive-int               $segmentSize
+     */
+    public function create(
+        array $command,
+        string $workingDirectory,
+        ?array $extraEnvironmentVariables,
+        int $numberOfProcesses,
+        int $segmentSize,
+        Logger $logger,
+        Closure $callback
+    ): ProcessLauncher;
+}

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Webmozarts\Console\Parallelization;
+namespace Webmozarts\Console\Parallelization\Process;
 
 use Closure;
 use Symfony\Component\Process\InputStream;
@@ -26,7 +26,7 @@ use Webmozarts\Console\Parallelization\Logger\Logger;
  * of the data set via its standard input, separated by newlines. The size
  * of this share can be configured in the constructor (the segment size).
  */
-class ProcessLauncher
+final class SymfonyProcessLauncher implements ProcessLauncher
 {
     /**
      * @var list<string>

--- a/src/Process/SymfonyProcessLauncherFactory.php
+++ b/src/Process/SymfonyProcessLauncherFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Process;
+
+use Closure;
+use Webmozarts\Console\Parallelization\Logger\Logger;
+
+final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
+{
+    /**
+     * @param list<string>               $command
+     * @param array<string, string>|null $extraEnvironmentVariables
+     * @param positive-int               $numberOfProcesses
+     * @param positive-int               $segmentSize
+     */
+    public function create(
+        array $command,
+        string $workingDirectory,
+        ?array $extraEnvironmentVariables,
+        int $numberOfProcesses,
+        int $segmentSize,
+        Logger $logger,
+        Closure $callback
+    ): ProcessLauncher {
+        return new SymfonyProcessLauncher(
+            $command,
+            $workingDirectory,
+            $extraEnvironmentVariables,
+            $numberOfProcesses,
+            $segmentSize,
+            $logger,
+            $callback,
+        );
+    }
+}

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -16,6 +16,7 @@ namespace Webmozarts\Console\Parallelization;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputDefinition;
 use Webmozarts\Console\Parallelization\ErrorHandler\FakeErrorHandler;
+use Webmozarts\Console\Parallelization\Process\FakeProcessLauncherFactory;
 
 /**
  * @covers \Webmozarts\Console\Parallelization\ParallelExecutorFactory
@@ -44,15 +45,16 @@ final class ParallelExecutorFactoryTest extends TestCase
         $segmentSize = 20;
         $extraEnvironmentVariables = ['CUSTOM_CI' => '0'];
         $progressSymbol = 'ø';
+        $processLauncherFactory = new FakeProcessLauncherFactory();
 
         $executor = ParallelExecutorFactory::create(
-            $callable0,
-            $callable1,
-            $callable2,
-            $commandName,
-            $definition,
-            $errorHandler,
-        )
+                $callable0,
+                $callable1,
+                $callable2,
+                $commandName,
+                $definition,
+                $errorHandler,
+            )
             ->withBatchSize($batchSize)
             ->withSegmentSize($segmentSize)
             ->withRunBeforeFirstCommand($callable3)
@@ -64,6 +66,7 @@ final class ParallelExecutorFactoryTest extends TestCase
             ->withScriptPath(self::FILE_2)
             ->withWorkingDirectory(self::FILE_3)
             ->withExtraEnvironmentVariables($extraEnvironmentVariables)
+            ->withProcessLauncherFactory($processLauncherFactory)
             ->build();
 
         $expected = new ParallelExecutor(
@@ -84,6 +87,7 @@ final class ParallelExecutorFactoryTest extends TestCase
             self::FILE_2,
             self::FILE_3,
             $extraEnvironmentVariables,
+            $processLauncherFactory,
         );
 
         self::assertEquals($expected, $executor);

--- a/tests/Process/FakeProcessLauncherFactory.php
+++ b/tests/Process/FakeProcessLauncherFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Process;
+
+use Closure;
+use DomainException;
+use Webmozarts\Console\Parallelization\Logger\Logger;
+
+final class FakeProcessLauncherFactory implements ProcessLauncherFactory
+{
+    public function create(
+        array $command,
+        string $workingDirectory,
+        ?array $extraEnvironmentVariables,
+        int $numberOfProcesses,
+        int $segmentSize,
+        Logger $logger,
+        Closure $callback
+    ): ProcessLauncher {
+        throw new DomainException('Unexpected call.');
+    }
+}


### PR DESCRIPTION
This opens the door for more easily testing `ParallelExecutor` as well as the future possibility to have another based process launcher, for example based on GNU parallel or AMPHP.