### PR TITLE
doc: remove ContainerAwareCommand reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,12 @@ Example
 -------
 
 ```php
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozarts\Console\Parallelization\Parallelization;
 
-class ImportMoviesCommand extends ContainerAwareCommand
+class ImportMoviesCommand extends Command
 {
     use Parallelization;
 


### PR DESCRIPTION
Since it has been removed in https://github.com/webmozarts/console-parallelization/commit/9fec119dd3fd198da94e960c5f657e0bc24b07eb

PS: thanks for your work :) 