### PR TITLE
Rename "number of batches" to "total number of batches"

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -32,7 +32,7 @@ final class Configuration
     /**
      * @var positive-int
      */
-    private int $numberOfBatches;
+    private int $totalNumberOfBatches;
 
     /**
      * @param positive-int   $numberOfProcesses
@@ -63,7 +63,7 @@ final class Configuration
             ? $numberOfItems
             : $segmentSize;
         $this->numberOfSegments = (int) (1 === $numberOfProcesses ? 1 : ceil($numberOfItems / $segmentSize));
-        $this->numberOfBatches = (int) (ceil($segmentSize / $batchSize) * $this->numberOfSegments);
+        $this->totalNumberOfBatches = (int) (ceil($segmentSize / $batchSize) * $this->numberOfSegments);
     }
 
     /**
@@ -85,8 +85,8 @@ final class Configuration
     /**
      * @return positive-int
      */
-    public function getNumberOfBatches(): int
+    public function getTotalNumberOfBatches(): int
     {
-        return $this->numberOfBatches;
+        return $this->totalNumberOfBatches;
     }
 }

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -22,7 +22,7 @@ interface Logger
         int $batchSize,
         int $numberOfItems,
         int $numberOfSegments,
-        int $numberOfBatches,
+        int $totalNumberOfBatches,
         int $numberOfProcesses,
         string $itemName
     ): void;

--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -22,7 +22,7 @@ final class NullLogger implements Logger
         int $batchSize,
         int $numberOfItems,
         int $numberOfSegments,
-        int $numberOfBatches,
+        int $totalNumberOfBatches,
         int $numberOfProcesses,
         string $itemName
     ): void {

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -48,7 +48,7 @@ final class StandardLogger implements Logger
         int $batchSize,
         int $numberOfItems,
         int $numberOfSegments,
-        int $numberOfBatches,
+        int $totalNumberOfBatches,
         int $numberOfProcesses,
         string $itemName
     ): void {
@@ -60,8 +60,8 @@ final class StandardLogger implements Logger
             $batchSize,
             $numberOfSegments,
             1 === $numberOfSegments ? 'round' : 'rounds',
-            $numberOfBatches,
-            1 === $numberOfBatches ? 'batch' : 'batches',
+            $totalNumberOfBatches,
+            1 === $totalNumberOfBatches ? 'batch' : 'batches',
             $numberOfProcesses,
             1 === $numberOfProcesses ? 'process' : 'processes',
         ));

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -228,7 +228,7 @@ final class ParallelExecutor
         );
 
         $numberOfSegments = $config->getNumberOfSegments();
-        $numberOfBatches = $config->getNumberOfBatches();
+        $totalNumberOfBatches = $config->getTotalNumberOfBatches();
         $itemName = ($this->getItemName)($numberOfItems);
 
         $logger->logConfiguration(
@@ -236,7 +236,7 @@ final class ParallelExecutor
             $batchSize,
             $numberOfItems,
             $numberOfSegments,
-            $numberOfBatches,
+            $totalNumberOfBatches,
             $numberOfProcesses,
             $itemName,
         );

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -47,7 +47,7 @@ final class ConfigurationTest extends TestCase
 
         self::assertSame($expectedSegmentSize, $config->getSegmentSize());
         self::assertSame($expectedNumberOfSegments, $config->getNumberOfSegments());
-        self::assertSame($expectedNumberOfBatches, $config->getNumberOfBatches());
+        self::assertSame($expectedNumberOfBatches, $config->getTotalNumberOfBatches());
     }
 
     /**

--- a/tests/Logger/DummyLogger.php
+++ b/tests/Logger/DummyLogger.php
@@ -25,7 +25,7 @@ final class DummyLogger implements Logger
         int $batchSize,
         int $numberOfItems,
         int $numberOfSegments,
-        int $numberOfBatches,
+        int $totalNumberOfBatches,
         int $numberOfProcesses,
         string $itemName
     ): void {

--- a/tests/Logger/FakeLogger.php
+++ b/tests/Logger/FakeLogger.php
@@ -23,7 +23,7 @@ final class FakeLogger implements Logger
         int $batchSize,
         int $numberOfItems,
         int $numberOfSegments,
-        int $numberOfBatches,
+        int $totalNumberOfBatches,
         int $numberOfProcesses,
         string $itemName
     ): void {

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -53,7 +53,7 @@ final class StandardLoggerTest extends TestCase
         int $batchSize,
         int $numberOfItems,
         int $numberOfSegments,
-        int $numberOfBatches,
+        int $totalNumberOfBatches,
         int $numberOfProcesses,
         string $itemName,
         string $expected
@@ -63,7 +63,7 @@ final class StandardLoggerTest extends TestCase
             $batchSize,
             $numberOfItems,
             $numberOfSegments,
-            $numberOfBatches,
+            $totalNumberOfBatches,
             $numberOfProcesses,
             $itemName,
         );

--- a/tests/ParallelExecutorTest.php
+++ b/tests/ParallelExecutorTest.php
@@ -868,7 +868,7 @@ final class ParallelExecutorTest extends TestCase
         $numberOfProcesses = 5;
         $numberOfProcessesDefined = true;
         $numberOfSegments = 2;
-        $numberOfBatches = 2;
+        $totalNumberOfBatches = 2;
 
         $input = new StringInput('');
         $output = new BufferedOutput();
@@ -912,7 +912,7 @@ final class ParallelExecutorTest extends TestCase
                         $batchSize,
                         3,
                         $numberOfSegments,
-                        $numberOfBatches,
+                        $totalNumberOfBatches,
                         $numberOfProcesses,
                         'items',
                     ],
@@ -937,7 +937,7 @@ final class ParallelExecutorTest extends TestCase
         $segmentSize = 3;
         $numberOfProcesses = 1;
         $numberOfSegments = 1;
-        $numberOfBatches = 2;
+        $totalNumberOfBatches = 2;
 
         $input = new StringInput('');
         $output = new BufferedOutput();
@@ -1003,7 +1003,7 @@ final class ParallelExecutorTest extends TestCase
                         $batchSize,
                         3,
                         $numberOfSegments,
-                        $numberOfBatches,
+                        $totalNumberOfBatches,
                         $numberOfProcesses,
                         'items',
                     ],


### PR DESCRIPTION
I think this new naming makes it less confusing as to whether the "number of batches" refers to the total number of batches executed or the number of batches executed within _each_ process