### PR TITLE
Ensure the items do not contain new lines

### DIFF
--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -148,7 +148,6 @@ final class ParallelExecutor
         self::validateSegmentSize($segmentSize);
         self::validateScriptPath($scriptPath);
         self::validateProgressSymbol($progressSymbol);
-        // TODO: validate that fetch items do not have new lines
 
         $this->fetchItems = $fetchItems;
         $this->runSingleCommand = $runSingleCommand;


### PR DESCRIPTION
This would otherwise mess up with the process communication since the child process takes the standard input exploded by new lines.