### PR TITLE
Make the process factory and process tick extendible

### DIFF
--- a/src/Process/ProcessLauncherFactory.php
+++ b/src/Process/ProcessLauncherFactory.php
@@ -33,7 +33,6 @@ interface ProcessLauncherFactory
         int $segmentSize,
         Logger $logger,
         callable $callback,
-        callable $tick,
-        SymfonyProcessFactory $processFactory
+        callable $tick
     ): ProcessLauncher;
 }

--- a/src/Process/SymfonyProcessLauncherFactory.php
+++ b/src/Process/SymfonyProcessLauncherFactory.php
@@ -17,6 +17,13 @@ use Webmozarts\Console\Parallelization\Logger\Logger;
 
 final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
 {
+    private SymfonyProcessFactory $processFactory;
+
+    public function __construct(SymfonyProcessFactory $processFactory)
+    {
+        $this->processFactory = $processFactory;
+    }
+
     /**
      * @param list<string>                   $command
      * @param array<string, string>|null     $extraEnvironmentVariables
@@ -33,8 +40,7 @@ final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
         int $segmentSize,
         Logger $logger,
         callable $callback,
-        callable $tick,
-        SymfonyProcessFactory $processFactory
+        callable $tick
     ): ProcessLauncher {
         return new SymfonyProcessLauncher(
             $command,
@@ -45,7 +51,7 @@ final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
             $logger,
             $callback,
             $tick,
-            $processFactory,
+            $this->processFactory,
         );
     }
 }

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -49,6 +49,7 @@ final class ParallelExecutorFactoryTest extends TestCase
         $callable4 = self::createCallable(4);
         $callable5 = self::createCallable(5);
         $callable6 = self::createCallable(6);
+        $callable7 = self::createCallable(7);
 
         $childSourceStream = StringStream::fromString('');
         $batchSize = 10;
@@ -78,6 +79,7 @@ final class ParallelExecutorFactoryTest extends TestCase
             ->withWorkingDirectory(self::FILE_3)
             ->withExtraEnvironmentVariables($extraEnvironmentVariables)
             ->withProcessLauncherFactory($processLauncherFactory)
+            ->withProcessTick($callable7)
             ->build();
 
         $expected = new ParallelExecutor(
@@ -100,6 +102,7 @@ final class ParallelExecutorFactoryTest extends TestCase
             self::FILE_3,
             $extraEnvironmentVariables,
             $processLauncherFactory,
+            $callable7,
         );
 
         self::assertEquals($expected, $executor);

--- a/tests/ParallelExecutorTest.php
+++ b/tests/ParallelExecutorTest.php
@@ -36,7 +36,6 @@ use Webmozarts\Console\Parallelization\Logger\FakeLogger;
 use Webmozarts\Console\Parallelization\Process\FakeProcessLauncherFactory;
 use Webmozarts\Console\Parallelization\Process\ProcessLauncher;
 use Webmozarts\Console\Parallelization\Process\ProcessLauncherFactory;
-use Webmozarts\Console\Parallelization\Process\StandardSymfonyProcessFactory;
 use function array_fill;
 use function func_get_args;
 use function getcwd;
@@ -427,7 +426,6 @@ final class ParallelExecutorTest extends TestCase
                 $logger,
                 Argument::type('callable'),
                 Argument::type('callable'),
-                Argument::type(StandardSymfonyProcessFactory::class),
             )
             ->willReturn($processLauncherProphecy->reveal());
 
@@ -451,6 +449,7 @@ final class ParallelExecutorTest extends TestCase
             $workingDirectory,
             $extraEnvironmentVariables,
             $processLauncherFactoryProphecy->reveal(),
+            static function (): void {},
         );
 
         $executor->execute(
@@ -1018,6 +1017,7 @@ final class ParallelExecutorTest extends TestCase
             __DIR__,
             null,
             new FakeProcessLauncherFactory(),
+            static function (): void {},
         );
     }
 
@@ -1069,6 +1069,7 @@ final class ParallelExecutorTest extends TestCase
             __DIR__,
             null,
             $processLauncherFactory,
+            static function (): void {},
         );
     }
 

--- a/tests/Process/FakeProcessLauncherFactory.php
+++ b/tests/Process/FakeProcessLauncherFactory.php
@@ -26,8 +26,7 @@ final class FakeProcessLauncherFactory implements ProcessLauncherFactory
         int $segmentSize,
         Logger $logger,
         callable $callback,
-        callable $tick,
-        SymfonyProcessFactory $processFactory
+        callable $tick
     ): ProcessLauncher {
         throw new DomainException('Unexpected call.');
     }


### PR DESCRIPTION
- Make the `ProcessFactory` extendible by passing it directly as a property of the process launcher factory which can be overridden with `ParallelExecutorFactory::withProcessLauncherFactory()`
- Make the tick function extendible via `ParallelExecutorFactory::withProcessTick()`