### PR TITLE
Restaure default batch size configuration

### DIFF
--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -151,8 +151,8 @@ final class ParallelExecutor
         ProcessLauncherFactory $processLauncherFactory,
         callable $processTick
     ) {
-        self::validateBatchSize($batchSize);
         self::validateSegmentSize($segmentSize);
+        self::validateBatchSize($batchSize);
         self::validateScriptPath($scriptPath);
         self::validateProgressSymbol($progressSymbol);
 

--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -61,6 +61,8 @@ final class ParallelExecutorFactory
      */
     private int $batchSize;
 
+    private bool $useDefaultBatchSize = true;
+
     /**
      * @var positive-int
      */
@@ -226,13 +228,12 @@ final class ParallelExecutorFactory
     {
         $clone = clone $this;
         $clone->batchSize = $batchSize;
+        $clone->useDefaultBatchSize = false;
 
         return $clone;
     }
 
     /**
-     * TODO: restore the behaviour that the default batch size is the segment size.
-     *
      * The number of items to process per child process. This is done in order
      * to circumvent some issues recurring to long living processes such as
      * memory leaks.
@@ -397,7 +398,7 @@ final class ParallelExecutorFactory
             $this->commandDefinition,
             $this->errorHandler,
             $this->childSourceStream,
-            $this->batchSize,
+            $this->useDefaultBatchSize ? $this->segmentSize : $this->batchSize,
             $this->segmentSize,
             $this->runBeforeFirstCommand,
             $this->runAfterLastCommand,

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -108,6 +108,84 @@ final class ParallelExecutorFactoryTest extends TestCase
         self::assertEquals($expected, $executor);
     }
 
+    public function test_it_sets_the_batch_size_to_the_segment_size_by_default(): void
+    {
+        $commandName = 'import:items';
+        $definition = new InputDefinition();
+        $errorHandler = new FakeErrorHandler();
+
+        $callable0 = self::createCallable(0);
+        $callable1 = self::createCallable(1);
+        $callable2 = self::createCallable(2);
+
+        $segmentSize = 20;
+
+        $executor = ParallelExecutorFactory::create(
+            $callable0,
+            $callable1,
+            $callable2,
+            $commandName,
+            $definition,
+            $errorHandler,
+        )
+            ->withSegmentSize($segmentSize)
+            ->build();
+
+        $expected = ParallelExecutorFactory::create(
+            $callable0,
+            $callable1,
+            $callable2,
+            $commandName,
+            $definition,
+            $errorHandler,
+        )
+            ->withSegmentSize($segmentSize)
+            ->withBatchSize($segmentSize)
+            ->build();
+
+        self::assertEquals($expected, $executor);
+    }
+
+    public function test_it_keeps_the_batch_size_set_if_changed(): void
+    {
+        $commandName = 'import:items';
+        $definition = new InputDefinition();
+        $errorHandler = new FakeErrorHandler();
+
+        $callable0 = self::createCallable(0);
+        $callable1 = self::createCallable(1);
+        $callable2 = self::createCallable(2);
+
+        $batchSize = 10;
+        $segmentSize = 20;
+
+        $executor = ParallelExecutorFactory::create(
+            $callable0,
+            $callable1,
+            $callable2,
+            $commandName,
+            $definition,
+            $errorHandler,
+        )
+            ->withBatchSize($batchSize)
+            ->withSegmentSize($segmentSize)
+            ->build();
+
+        $expected = ParallelExecutorFactory::create(
+            $callable0,
+            $callable1,
+            $callable2,
+            $commandName,
+            $definition,
+            $errorHandler,
+        )
+            ->withSegmentSize($segmentSize)
+            ->withBatchSize($batchSize)
+            ->build();
+
+        self::assertEquals($expected, $executor);
+    }
+
     /**
      * @dataProvider defaultValuesProvider
      */


### PR DESCRIPTION
By default the batch size should match the segment size.