### PR TITLE
Always pass the full IO

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,6 @@
 ## From 1.x to 2.x
 
+- `Parallelization::fetchItems()` now requires `OutputInterface` as a second parameter
 - A lot more type-safety and validation has been added with a comprehensive
   message upon failure.
 - When no number of process is given (via `-p|--processes`), the command is no

--- a/src/ParallelCommand.php
+++ b/src/ParallelCommand.php
@@ -50,11 +50,9 @@ abstract class ParallelCommand extends Command
      *
      * This method is called exactly once in the main process.
      *
-     * @param InputInterface $input The console input
-     *
      * @return iterable<string> The items to process
      */
-    abstract protected function fetchItems(InputInterface $input): iterable;
+    abstract protected function fetchItems(InputInterface $input, OutputInterface $output): iterable;
 
     /**
      * Processes an item in the child process.
@@ -89,19 +87,19 @@ abstract class ParallelCommand extends Command
 
         return $this
             ->getParallelExecutableFactory(
-                fn (InputInterface $input) => $this->fetchItems($input),
+                fn (InputInterface $input) => $this->fetchItems($input, $output),
                 fn (string $item, InputInterface $input, OutputInterface $output) => $this->runSingleCommand($item, $input, $output),
                 Closure::fromCallable([$this, 'getItemName']),
                 $commandName,
                 $this->getDefinition(),
-                $this->createErrorHandler($output),
+                $this->createErrorHandler($input, $output),
             )
             ->build()
             ->execute(
                 $parallelizationInput,
                 $input,
                 $output,
-                $this->createLogger($output),
+                $this->createLogger($input, $output),
             );
     }
 
@@ -128,7 +126,7 @@ abstract class ParallelCommand extends Command
         );
     }
 
-    protected function createErrorHandler(OutputInterface $output): ErrorHandler
+    protected function createErrorHandler(InputInterface $input, OutputInterface $output): ErrorHandler
     {
         return new LoggingErrorHandler(
             new ThrowableCodeErrorHandler(
@@ -137,7 +135,7 @@ abstract class ParallelCommand extends Command
         );
     }
 
-    protected function createLogger(OutputInterface $output): Logger
+    protected function createLogger(InputInterface $input, OutputInterface $output): Logger
     {
         return new StandardLogger(
             $output,

--- a/tests/Fixtures/Command/FrameworkLessCommand.php
+++ b/tests/Fixtures/Command/FrameworkLessCommand.php
@@ -24,7 +24,7 @@ final class FrameworkLessCommand extends ParallelCommand
         parent::__construct('test:no-framework');
     }
 
-    protected function fetchItems(InputInterface $input): iterable
+    protected function fetchItems(InputInterface $input, OutputInterface $output): iterable
     {
         return ['item0', 'item1'];
     }

--- a/tests/Fixtures/Command/ImportMoviesCommand.php
+++ b/tests/Fixtures/Command/ImportMoviesCommand.php
@@ -58,7 +58,7 @@ final class ImportMoviesCommand extends Command
     /**
      * @return list<string>
      */
-    protected function fetchItems(InputInterface $input): array
+    protected function fetchItems(InputInterface $input, OutputInterface $output): array
     {
         return [
             'movie-1.json',
@@ -115,7 +115,7 @@ final class ImportMoviesCommand extends Command
         return 1 === $count ? 'movie' : 'movies';
     }
 
-    protected function createLogger(OutputInterface $output): Logger
+    protected function createLogger(InputInterface $input, OutputInterface $output): Logger
     {
         return new StandardLogger(
             $output,

--- a/tests/Fixtures/Command/ImportUnknownMoviesCountCommand.php
+++ b/tests/Fixtures/Command/ImportUnknownMoviesCountCommand.php
@@ -46,7 +46,7 @@ final class ImportUnknownMoviesCountCommand extends ParallelCommand
         $this->logger = new TestLogger();
     }
 
-    protected function fetchItems(InputInterface $input): iterable
+    protected function fetchItems(InputInterface $input, OutputInterface $output): iterable
     {
         return yield from [
             'movie-1.json',
@@ -103,7 +103,7 @@ final class ImportUnknownMoviesCountCommand extends ParallelCommand
         return 1 === $count ? 'movie' : 'movies';
     }
 
-    protected function createLogger(OutputInterface $output): Logger
+    protected function createLogger(InputInterface $input, OutputInterface $output): Logger
     {
         return new StandardLogger(
             $output,

--- a/tests/Fixtures/Command/LegacyCommand.php
+++ b/tests/Fixtures/Command/LegacyCommand.php
@@ -88,7 +88,7 @@ final class LegacyCommand extends Command
         return $this->container;
     }
 
-    public function fetchItems(InputInterface $input): array
+    public function fetchItems(InputInterface $input, OutputInterface $output): array
     {
         $items = [];
 
@@ -138,7 +138,7 @@ final class LegacyCommand extends Command
 
     private function executeDryRun(InputInterface $input, OutputInterface $output): int
     {
-        $items = $this->fetchItems($input);
+        $items = $this->fetchItems($input, $output);
 
         foreach ($items as $index => $item) {
             $output->writeln(

--- a/tests/Fixtures/Command/NoSubProcessCommand.php
+++ b/tests/Fixtures/Command/NoSubProcessCommand.php
@@ -45,7 +45,7 @@ final class NoSubProcessCommand extends Command
     /**
      * @return list<string>
      */
-    protected function fetchItems(InputInterface $input): array
+    protected function fetchItems(InputInterface $input, OutputInterface $output): array
     {
         return [
             'item1',
@@ -94,7 +94,7 @@ final class NoSubProcessCommand extends Command
         return 1 === $count ? 'item' : 'items';
     }
 
-    protected function createLogger(OutputInterface $output): Logger
+    protected function createLogger(InputInterface $input, OutputInterface $output): Logger
     {
         return new StandardLogger(
             $output,


### PR DESCRIPTION
This more of a bigger BC break with the last beta since it changes the signature of 2 new methods, and one annoying BC break for when coming to 1.x.

The reason why I'm willing to introduce this change nonetheless is because I believe it is much more future-proof. Indeed although passing both the input & output may look useless at first glance, as soon as you are using `SymfonyStyle` for example, you will need both.