### PR TITLE
Improve the Logger API

### DIFF
--- a/phpstan-src.neon.dist
+++ b/phpstan-src.neon.dist
@@ -9,3 +9,7 @@ parameters:
 
         - path: src/CpuCoreCounter.php
           message: '#getNumberOfCpuCores\(\) should return#'
+
+        # https://github.com/phpstan/phpstan/issues/8222
+        - path: src/Process/SymfonyProcessLauncher.php
+          message: '#\$runningProcesses \(array<int<0, max>, .*>\) does not accept non-empty-array<int, .*>\.#'

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -19,8 +19,12 @@ use Webmozarts\Console\Parallelization\Configuration;
 interface Logger
 {
     /**
+     * Logs the configuration before the start of the processing.
+     *
      * @param positive-int        $batchSize
      * @param 0|positive-int|null $numberOfItems
+     * @param string              $itemName      Name of the item; Already in the singular or plural
+     *                                           form.
      */
     public function logConfiguration(
         Configuration $configuration,
@@ -33,17 +37,47 @@ interface Logger
     /**
      * @param 0|positive-int|null $numberOfItems
      */
-    public function startProgress(?int $numberOfItems): void;
+    public function logStart(?int $numberOfItems): void;
 
-    public function advance(int $steps = 1): void;
+    /**
+     * @param positive-int|0 $steps
+     */
+    public function logAdvance(int $steps = 1): void;
 
-    public function finish(string $itemName): void;
-
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void;
-
-    public function logCommandStarted(string $commandName): void;
-
-    public function logCommandFinished(): void;
+    /**
+     * @param string $itemName Name of the item; Already in the singular or plural form.
+     */
+    public function logFinish(string $itemName): void;
 
     public function logItemProcessingFailed(string $item, Throwable $throwable): void;
+
+    /**
+     * @param positive-int|0 $index       Index of the process amoung the list of running processes.
+     * @param string         $commandName Executed command for the child process.To not confuse
+     *                                    with the Symfony command name which is just an element of
+     *                                    the command.
+     */
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void;
+
+    /**
+     * @param positive-int|0 $index Index of the process amoung the list of running processes.
+     */
+    public function logChildProcessFinished(int $index): void;
+
+    /**
+     * Logs the "unexpected" child output. By unexpected is meant that the main
+     * process expects the child to output the progress symbol to communicate its
+     * progression. Any other sort of output is considered "unexpected".
+     *
+     * @param string         $buffer Child process output.
+     * @param positive-int|0 $index  Index of the process amoung the list of running processes.
+     * @param int|null       $pid    The child process PID. It can be null if the process is no
+     *                               longer running.
+     */
+    public function logUnexpectedChildProcessOutput(
+        int $index,
+        ?int $pid,
+        string $buffer,
+        string $progressSymbol
+    ): void;
 }

--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -43,22 +43,22 @@ final class NullLogger implements Logger
         // Do nothing.
     }
 
-    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
-    {
-        // Do nothing.
-    }
-
     public function logItemProcessingFailed(string $item, Throwable $throwable): void
     {
         // Do nothing.
     }
 
-    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
     {
         // Do nothing.
     }
 
     public function logChildProcessFinished(int $index): void
+    {
+        // Do nothing.
+    }
+
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         // Do nothing.
     }

--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -28,37 +28,37 @@ final class NullLogger implements Logger
         // Do nothing.
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         // Do nothing.
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         // Do nothing.
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         // Do nothing.
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
-    {
-        // Do nothing.
-    }
-
-    public function logCommandStarted(string $commandName): void
-    {
-        // Do nothing.
-    }
-
-    public function logCommandFinished(): void
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
     {
         // Do nothing.
     }
 
     public function logItemProcessingFailed(string $item, Throwable $throwable): void
+    {
+        // Do nothing.
+    }
+
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
+    {
+        // Do nothing.
+    }
+
+    public function logChildProcessFinished(int $index): void
     {
         // Do nothing.
     }

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -85,7 +85,7 @@ final class StandardLogger implements Logger
         $this->output->writeln('');
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         Assert::false(
             isset($this->progressBar),
@@ -98,7 +98,7 @@ final class StandardLogger implements Logger
         );
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         Assert::true(
             isset($this->progressBar),
@@ -108,7 +108,7 @@ final class StandardLogger implements Logger
         $this->progressBar->advance($steps);
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         Assert::true(
             isset($this->progressBar),
@@ -128,7 +128,7 @@ final class StandardLogger implements Logger
         unset($this->progressBar);
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         $this->output->writeln('');
         $this->output->writeln(sprintf(
@@ -144,12 +144,12 @@ final class StandardLogger implements Logger
         $this->output->writeln('');
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
     {
         $this->logger->debug('Command started: '.$commandName);
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(int $index): void
     {
         $this->logger->debug('Command finished');
     }

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -128,6 +128,26 @@ final class StandardLogger implements Logger
         unset($this->progressBar);
     }
 
+    public function logItemProcessingFailed(string $item, Throwable $throwable): void
+    {
+        $this->output->writeln(sprintf(
+            "Failed to process \"%s\": %s\n%s",
+            $item,
+            $throwable->getMessage(),
+            $throwable->getTraceAsString(),
+        ));
+    }
+
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
+    {
+        $this->logger->debug('Command started: '.$commandName);
+    }
+
+    public function logChildProcessFinished(int $index): void
+    {
+        $this->logger->debug('Command finished');
+    }
+
     public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         $this->output->writeln('');
@@ -142,25 +162,5 @@ final class StandardLogger implements Logger
         ));
         $this->output->writeln(str_replace($progressSymbol, '', $buffer));
         $this->output->writeln('');
-    }
-
-    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
-    {
-        $this->logger->debug('Command started: '.$commandName);
-    }
-
-    public function logChildProcessFinished(int $index): void
-    {
-        $this->logger->debug('Command finished');
-    }
-
-    public function logItemProcessingFailed(string $item, Throwable $throwable): void
-    {
-        $this->output->writeln(sprintf(
-            "Failed to process \"%s\": %s\n%s",
-            $item,
-            $throwable->getMessage(),
-            $throwable->getTraceAsString(),
-        ));
     }
 }

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -231,7 +231,7 @@ final class ParallelExecutor
             $shouldSpawnChildProcesses,
         );
 
-        $logger->startProgress($numberOfItems);
+        $logger->logStart($numberOfItems);
 
         if ($shouldSpawnChildProcesses) {
             $exitCode = $this
@@ -248,11 +248,11 @@ final class ParallelExecutor
                 $input,
                 $output,
                 $logger,
-                static fn () => $logger->advance(),
+                static fn () => $logger->logAdvance(),
             );
         }
 
-        $logger->finish($itemName);
+        $logger->logFinish($itemName);
 
         ($this->runAfterLastCommand)($input, $output);
 
@@ -353,17 +353,28 @@ final class ParallelExecutor
             $numberOfProcesses,
             $segmentSize,
             $logger,
-            fn (string $type, string $buffer) => $this->processChildOutput($buffer, $logger),
+            fn (int $index, ?int $pid, string $type, string $buffer) => $this->processChildOutput(
+                $index,
+                $pid,
+                $buffer,
+                $logger,
+            ),
             $this->processTick,
         );
     }
 
     /**
+     * TODO: pass the type
      * Called whenever data is received in the main process from a child process.
      *
-     * @param string $buffer The received data
+     * @param positive-int|0 $index  Index of the process amoung the list of running processes.
+     * @param int|null       $pid    The child process PID. It can be null if the process is no
+     *                               longer running.
+     * @param string         $buffer The received data
      */
     private function processChildOutput(
+        int $index,
+        ?int $pid,
         string $buffer,
         Logger $logger
     ): void {
@@ -372,10 +383,15 @@ final class ParallelExecutor
 
         // Display unexpected output
         if ($charactersCount !== mb_strlen($buffer)) {
-            $logger->logUnexpectedOutput($buffer, $progressSymbol);
+            $logger->logUnexpectedChildProcessOutput(
+                $index,
+                $pid,
+                $buffer,
+                $progressSymbol,
+            );
         }
 
-        $logger->advance($charactersCount);
+        $logger->logAdvance($charactersCount);
     }
 
     private static function validateBatchSize(int $batchSize): void

--- a/src/Process/ProcessLauncherFactory.php
+++ b/src/Process/ProcessLauncherFactory.php
@@ -15,15 +15,20 @@ namespace Webmozarts\Console\Parallelization\Process;
 
 use Webmozarts\Console\Parallelization\Logger\Logger;
 
+/**
+ * @phpstan-type ProcessOutput callable(positive-int|0, int|null, string, string): void
+ */
 interface ProcessLauncherFactory
 {
     /**
-     * @param list<string>                   $command
-     * @param array<string, string>|null     $extraEnvironmentVariables
-     * @param positive-int                   $numberOfProcesses
-     * @param positive-int                   $segmentSize
-     * @param callable(string, string): void $callback
-     * @param callable(): void               $tick
+     * @param list<string>               $command
+     * @param array<string, string>|null $extraEnvironmentVariables
+     * @param positive-int               $numberOfProcesses
+     * @param positive-int               $segmentSize
+     * @param ProcessOutput              $processOutput             A PHP callback which is run whenever
+     *                                                              there is some output available on
+     *                                                              STDOUT or STDERR.
+     * @param callable(): void           $tick
      */
     public function create(
         array $command,
@@ -32,7 +37,7 @@ interface ProcessLauncherFactory
         int $numberOfProcesses,
         int $segmentSize,
         Logger $logger,
-        callable $callback,
+        callable $processOutput,
         callable $tick
     ): ProcessLauncher;
 }

--- a/src/Process/StandardSymfonyProcessFactory.php
+++ b/src/Process/StandardSymfonyProcessFactory.php
@@ -20,11 +20,12 @@ use function method_exists;
 final class StandardSymfonyProcessFactory implements SymfonyProcessFactory
 {
     public function startProcess(
+        int $index,
         InputStream $inputStream,
         array $command,
         string $workingDirectory,
         ?array $environmentVariables,
-        callable $callback
+        callable $processOutput
     ): Process {
         $process = new Process(
             $command,
@@ -42,7 +43,14 @@ final class StandardSymfonyProcessFactory implements SymfonyProcessFactory
             $process->inheritEnvironmentVariables(true);
         }
         // @codeCoverageIgnoreEnd
-        $process->start($callback);
+        $process->start(
+            fn (string $type, string $buffer) => $processOutput(
+                $index,
+                $process->getPid(),
+                $type,
+                $buffer,
+            ),
+        );
 
         return $process;
     }

--- a/src/Process/SymfonyProcessFactory.php
+++ b/src/Process/SymfonyProcessFactory.php
@@ -16,20 +16,28 @@ namespace Webmozarts\Console\Parallelization\Process;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
+/**
+ * @phpstan-type ProcessOutput callable(positive-int|0, int|null, string, string): void
+ */
 interface SymfonyProcessFactory
 {
     /**
      * Starts a single process reading from the given input stream.
      *
-     * @param list<string>                   $command
-     * @param array<string, string>|null     $environmentVariables
-     * @param callable(string, string): void $callback
+     * @param positive-int|0             $index                Index of the process amoung the
+     *                                                         list of running processes.
+     * @param list<string>               $command
+     * @param array<string, string>|null $environmentVariables
+     * @param ProcessOutput              $processOutput        A PHP callback which is run whenever
+     *                                                         there is some output available on
+     *                                                         STDOUT or STDERR.
      */
     public function startProcess(
+        int $index,
         InputStream $inputStream,
         array $command,
         string $workingDirectory,
         ?array $environmentVariables,
-        callable $callback
+        callable $processOutput
     ): Process;
 }

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -19,6 +19,7 @@ use Webmozart\Assert\Assert;
 use Webmozarts\Console\Parallelization\Logger\Logger;
 use function count;
 use function sprintf;
+use const PHP_EOL;
 
 /**
  * Launches a number of processes and distributes data among these processes.
@@ -221,6 +222,11 @@ final class SymfonyProcessLauncher implements ProcessLauncher
         unset($this->runningProcesses[$index]);
 
         $exitCode = $process->getExitCode();
+
+        if (-1 === $exitCode) {
+            \file_put_contents('php://stderr', PHP_EOL.PHP_EOL.$process->getOutput().";".$process->getErrorOutput().PHP_EOL.PHP_EOL);
+        }
+
         Assert::natural(
             $exitCode,
             sprintf(

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -212,6 +212,8 @@ final class SymfonyProcessLauncher implements ProcessLauncher
 
     /**
      * @param positive-int|0 $index
+     *
+     * @return positive-int|0
      */
     private function freeProcess(int $index, Process $process): int
     {
@@ -229,7 +231,7 @@ final class SymfonyProcessLauncher implements ProcessLauncher
     {
         $exitCode = $process->getExitCode();
 
-// @codeCoverageIgnoreStart
+        // @codeCoverageIgnoreStart
         if (null !== $exitCode && $exitCode < 0) {
             // A negative exit code indicates the process has been terminated by
             // a signal.

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -221,7 +221,13 @@ final class SymfonyProcessLauncher implements ProcessLauncher
         unset($this->runningProcesses[$index]);
 
         $exitCode = $process->getExitCode();
-        Assert::natural($exitCode, 'Expected the process to be finished and return a valid exit code. Got "%s" instead');
+        Assert::natural(
+            $exitCode,
+            sprintf(
+                'Expected the process to be finished and return a valid exit code. Got "%%s" (%s) instead.',
+                $process->getExitCodeText(),
+            ),
+        );
 
         return $exitCode;
     }

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -212,8 +212,6 @@ final class SymfonyProcessLauncher implements ProcessLauncher
 
     /**
      * @param positive-int|0 $index
-     *
-     * @return 0|positive-int
      */
     private function freeProcess(int $index, Process $process): int
     {
@@ -223,16 +221,9 @@ final class SymfonyProcessLauncher implements ProcessLauncher
 
         $exitCode = $process->getExitCode();
 
-        if (-1 === $exitCode) {
-            \file_put_contents('php://stderr', PHP_EOL.PHP_EOL.$process->getOutput().";".$process->getErrorOutput().PHP_EOL.PHP_EOL);
-        }
-
-        Assert::natural(
+        Assert::notNull(
             $exitCode,
-            sprintf(
-                'Expected the process to be finished and return a valid exit code. Got "%%s" (%s) instead.',
-                $process->getExitCodeText(),
-            ),
+            'Expected the process to have an exit code. Got "null" instead.',
         );
 
         return $exitCode;

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -221,7 +221,7 @@ final class SymfonyProcessLauncher implements ProcessLauncher
         unset($this->runningProcesses[$index]);
 
         $exitCode = $process->getExitCode();
-        Assert::natural($exitCode, 'Expected the process to be finished and return a valid exit code.');
+        Assert::natural($exitCode, 'Expected the process to be finished and return a valid exit code. Got "%s" instead');
 
         return $exitCode;
     }

--- a/src/Process/SymfonyProcessLauncherFactory.php
+++ b/src/Process/SymfonyProcessLauncherFactory.php
@@ -25,12 +25,14 @@ final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
     }
 
     /**
-     * @param list<string>                   $command
-     * @param array<string, string>|null     $extraEnvironmentVariables
-     * @param positive-int                   $numberOfProcesses
-     * @param positive-int                   $segmentSize
-     * @param callable(string, string): void $callback
-     * @param callable(): void               $tick
+     * @param list<string>                                             $command
+     * @param array<string, string>|null                               $extraEnvironmentVariables
+     * @param positive-int                                             $numberOfProcesses
+     * @param positive-int                                             $segmentSize
+     * @param callable(positive-int|0, int|null, string, string): void $processOutput             A PHP callback which is run whenever
+     *                                                                                            there is some output available on
+     *                                                                                            STDOUT or STDERR.
+     * @param callable(): void                                         $tick
      */
     public function create(
         array $command,
@@ -39,7 +41,7 @@ final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
         int $numberOfProcesses,
         int $segmentSize,
         Logger $logger,
-        callable $callback,
+        callable $processOutput,
         callable $tick
     ): ProcessLauncher {
         return new SymfonyProcessLauncher(
@@ -49,7 +51,7 @@ final class SymfonyProcessLauncherFactory implements ProcessLauncherFactory
             $numberOfProcesses,
             $segmentSize,
             $logger,
-            $callback,
+            $processOutput,
             $tick,
             $this->processFactory,
         );

--- a/tests/Logger/DummyLogger.php
+++ b/tests/Logger/DummyLogger.php
@@ -34,7 +34,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -42,7 +42,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -50,7 +50,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -58,7 +58,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -66,7 +66,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -74,7 +74,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(int $index): void
     {
         $this->records[] = [
             __FUNCTION__,

--- a/tests/Logger/DummyLogger.php
+++ b/tests/Logger/DummyLogger.php
@@ -58,7 +58,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
+    public function logItemProcessingFailed(string $item, Throwable $throwable): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -82,7 +82,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logItemProcessingFailed(string $item, Throwable $throwable): void
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         $this->records[] = [
             __FUNCTION__,

--- a/tests/Logger/FakeLogger.php
+++ b/tests/Logger/FakeLogger.php
@@ -44,7 +44,7 @@ final class FakeLogger implements Logger
         throw new DomainException('Unexpected call.');
     }
 
-    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
+    public function logItemProcessingFailed(string $item, Throwable $throwable): void
     {
         throw new DomainException('Unexpected call.');
     }
@@ -59,7 +59,7 @@ final class FakeLogger implements Logger
         throw new DomainException('Unexpected call.');
     }
 
-    public function logItemProcessingFailed(string $item, Throwable $throwable): void
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/Logger/FakeLogger.php
+++ b/tests/Logger/FakeLogger.php
@@ -29,32 +29,32 @@ final class FakeLogger implements Logger
         throw new DomainException('Unexpected call.');
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(int $index, ?int $pid, string $buffer, string $progressSymbol): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(int $index, int $pid, string $commandName): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(int $index): void
     {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -432,6 +432,32 @@ final class StandardLoggerTest extends TestCase
         $this->output->fetch();
 
         $this->logger->logUnexpectedChildProcessOutput(
+            2,
+            23123,
+            'An error occurred.',
+            self::ADVANCEMENT_CHARACTER,
+        );
+
+        $expected = <<<'TXT'
+
+            ================= Process Output =================
+            An error occurred.
+
+
+            TXT;
+
+        self::assertSame($expected, $this->output->fetch());
+    }
+
+    public function test_it_can_log_the_unexpected_output_of_a_stopped_child_process(): void
+    {
+        $this->logger->logStart(10);
+        $this->logger->logAdvance(4);
+        $this->output->fetch();
+
+        $this->logger->logUnexpectedChildProcessOutput(
+            2,
+            null,
             'An error occurred.',
             self::ADVANCEMENT_CHARACTER,
         );
@@ -454,6 +480,8 @@ final class StandardLoggerTest extends TestCase
         $this->output->fetch();
 
         $this->logger->logUnexpectedChildProcessOutput(
+            23,
+            23132,
             'An error'.self::ADVANCEMENT_CHARACTER.' occurred.',
             self::ADVANCEMENT_CHARACTER,
         );
@@ -473,7 +501,11 @@ final class StandardLoggerTest extends TestCase
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-        $this->logger->logChildProcessStarted('/path/to/bin/console foo:bar --child');
+        $this->logger->logChildProcessStarted(
+            2,
+            2132,
+            '/path/to/bin/console foo:bar --child',
+        );
 
         $expected = <<<'TXT'
             [debug] Command started: /path/to/bin/console foo:bar --child
@@ -487,7 +519,7 @@ final class StandardLoggerTest extends TestCase
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-        $this->logger->logChildProcessFinished();
+        $this->logger->logChildProcessFinished(3);
 
         $expected = <<<'TXT'
             [debug] Command finished

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -342,7 +342,7 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_can_log_the_start_of_the_processing(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
 
         $expected = <<<'TXT'
               0/10 [>---------------------------]   0%
@@ -353,20 +353,20 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_cannot_start_an_already_started_process(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot start the progress: already started.');
 
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
     }
 
     public function test_it_can_log_the_progress_of_the_processing(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
         $this->output->fetch();
 
-        $this->logger->advance();
+        $this->logger->logAdvance();
 
         $expected = <<<'TXT'
 
@@ -381,15 +381,15 @@ final class StandardLoggerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected the progress to be started.');
 
-        $this->logger->advance();
+        $this->logger->logAdvance();
     }
 
     public function test_it_can_log_the_progress_of_the_processing_of_multiple_items(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
         $this->output->fetch();
 
-        $this->logger->advance(4);
+        $this->logger->logAdvance(4);
 
         $expected = <<<'TXT'
 
@@ -401,10 +401,10 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_can_log_the_end_of_the_processing(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
         $this->output->fetch();
 
-        $this->logger->finish('tokens');
+        $this->logger->logFinish('tokens');
 
         $expected = <<<'TXT'
 
@@ -422,16 +422,16 @@ final class StandardLoggerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected the progress to be started.');
 
-        $this->logger->finish('tokens');
+        $this->logger->logFinish('tokens');
     }
 
     public function test_it_can_log_the_unexpected_output_of_a_child_process(): void
     {
-        $this->logger->startProgress(10);
-        $this->logger->advance(4);
+        $this->logger->logStart(10);
+        $this->logger->logAdvance(4);
         $this->output->fetch();
 
-        $this->logger->logUnexpectedOutput(
+        $this->logger->logUnexpectedChildProcessOutput(
             'An error occurred.',
             self::ADVANCEMENT_CHARACTER,
         );
@@ -449,11 +449,11 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_removes_the_progress_character_of_the_unexpected_output_of_a_child_process(): void
     {
-        $this->logger->startProgress(10);
-        $this->logger->advance(4);
+        $this->logger->logStart(10);
+        $this->logger->logAdvance(4);
         $this->output->fetch();
 
-        $this->logger->logUnexpectedOutput(
+        $this->logger->logUnexpectedChildProcessOutput(
             'An error'.self::ADVANCEMENT_CHARACTER.' occurred.',
             self::ADVANCEMENT_CHARACTER,
         );
@@ -473,7 +473,7 @@ final class StandardLoggerTest extends TestCase
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-        $this->logger->logCommandStarted('/path/to/bin/console foo:bar --child');
+        $this->logger->logChildProcessStarted('/path/to/bin/console foo:bar --child');
 
         $expected = <<<'TXT'
             [debug] Command started: /path/to/bin/console foo:bar --child
@@ -487,7 +487,7 @@ final class StandardLoggerTest extends TestCase
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-        $this->logger->logCommandFinished();
+        $this->logger->logChildProcessFinished();
 
         $expected = <<<'TXT'
             [debug] Command finished

--- a/tests/ParallelExecutorTest.php
+++ b/tests/ParallelExecutorTest.php
@@ -660,17 +660,17 @@ final class ParallelExecutorTest extends TestCase
             };
         };
 
-        $processCallback = FakeCallable::create();
+        $processOutput = FakeCallable::create();
 
         $processLauncherProphecy = $this->prophesize(ProcessLauncher::class);
         $processLauncherProphecy
             ->run(Argument::cetera())
-            ->will(static function () use ($progressSymbol, &$processCallback): int {
-                $processCallback('test', $progressSymbol);
-                $processCallback('test', 'FOO');    // unexpected output
-                $processCallback('test', $progressSymbol);
-                $processCallback('test', $progressSymbol.$progressSymbol.$progressSymbol);  // multi-step
-                $processCallback('test', $progressSymbol);
+            ->will(static function () use ($progressSymbol, &$processOutput): int {
+                $processOutput(10, null, 'test', $progressSymbol);
+                $processOutput(10, null, 'test', 'FOO');    // unexpected output
+                $processOutput(10, null, 'test', $progressSymbol);
+                $processOutput(10, null, 'test', $progressSymbol.$progressSymbol.$progressSymbol);  // multi-step
+                $processOutput(10, null, 'test', $progressSymbol);
 
                 return 0;
             });
@@ -678,8 +678,8 @@ final class ParallelExecutorTest extends TestCase
         $processLauncherFactoryProphecy = $this->prophesize(ProcessLauncherFactory::class);
         $processLauncherFactoryProphecy
             ->create(Argument::cetera())
-            ->will(static function (array $arguments) use ($processLauncherProphecy, &$processCallback) {
-                $processCallback = $arguments[6];
+            ->will(static function (array $arguments) use ($processLauncherProphecy, &$processOutput) {
+                $processOutput = $arguments[6];
 
                 return $processLauncherProphecy->reveal();
             });
@@ -735,7 +735,7 @@ final class ParallelExecutorTest extends TestCase
             ],
             [
                 'logUnexpectedChildProcessOutput',
-                ['FOO', $progressSymbol],
+                [10, null, 'FOO', $progressSymbol],
             ],
             [
                 'logAdvance',

--- a/tests/Process/DummyProcess74.php
+++ b/tests/Process/DummyProcess74.php
@@ -23,6 +23,11 @@ use function implode;
 
 final class DummyProcess74 extends Process
 {
+    /** @readonly */
+    public int $index;
+
+    private int $pid;
+
     /**
      * @var array<array{string, array}>
      */
@@ -51,6 +56,8 @@ final class DummyProcess74 extends Process
     private int $exitCode;
 
     public function __construct(
+        int $index,
+        int $pid,
         array $command,
         int $exitCode,
         ?string $cwd = null,
@@ -60,6 +67,8 @@ final class DummyProcess74 extends Process
     ) {
         parent::__construct($command, $cwd, $env, $input, $timeout);
 
+        $this->index = $index;
+        $this->pid = $pid;
         $this->command = $command;
         $this->exitCode = $exitCode;
     }
@@ -169,7 +178,7 @@ final class DummyProcess74 extends Process
 
     public function getPid(): ?int
     {
-        throw new DomainException('Unexpected call.');
+        return $this->started && !$this->stopped ? $this->pid : null;
     }
 
     public function signal($signal): void

--- a/tests/Process/DummyProcess74.php
+++ b/tests/Process/DummyProcess74.php
@@ -243,7 +243,7 @@ final class DummyProcess74 extends Process
 
     public function getExitCodeText(): ?string
     {
-        throw new DomainException('Unexpected call.');
+        return 'No explanation, this is a dummy text.';
     }
 
     public function isSuccessful(): bool

--- a/tests/Process/DummyProcess74.php
+++ b/tests/Process/DummyProcess74.php
@@ -142,7 +142,7 @@ final class DummyProcess74 extends Process
 
         $this->inputIterator->next();
         $this->processedItems[] = $item;
-        ($this->callback)('dummy', $item);
+        ($this->callback)($this->index, $this->getPid(), 'dummy', $item);
 
         return true;
     }

--- a/tests/Process/DummyProcess81.php
+++ b/tests/Process/DummyProcess81.php
@@ -151,7 +151,7 @@ final class DummyProcess81 extends Process
 
         $this->inputIterator->next();
         $this->processedItems[] = $item;
-        ($this->callback)(1, null, 'dummy', $item);
+        ($this->callback)($this->index, $this->getPid(), 'dummy', $item);
 
         return true;
     }

--- a/tests/Process/DummyProcess81.php
+++ b/tests/Process/DummyProcess81.php
@@ -23,6 +23,11 @@ use function implode;
 
 final class DummyProcess81 extends Process
 {
+    /** @readonly */
+    public int $index;
+
+    private int $pid;
+
     /**
      * @var array<array{string, array}>
      */
@@ -52,6 +57,8 @@ final class DummyProcess81 extends Process
     private int $exitCode;
 
     public function __construct(
+        int $index,
+        int $pid,
         array $command,
         int $exitCode,
         ?string $cwd = null,
@@ -61,6 +68,8 @@ final class DummyProcess81 extends Process
     ) {
         parent::__construct($command, $cwd, $env, $input, $timeout);
 
+        $this->index = $index;
+        $this->pid = $pid;
         $this->command = $command;
         $this->exitCode = $exitCode;
     }
@@ -142,7 +151,7 @@ final class DummyProcess81 extends Process
 
         $this->inputIterator->next();
         $this->processedItems[] = $item;
-        ($this->callback)('dummy', $item);
+        ($this->callback)(1, null, 'dummy', $item);
 
         return true;
     }
@@ -178,7 +187,7 @@ final class DummyProcess81 extends Process
 
     public function getPid(): ?int
     {
-        throw new DomainException('Unexpected call.');
+        return $this->started && !$this->stopped ? $this->pid : null;
     }
 
     public function signal(int $signal): static

--- a/tests/Process/DummyProcess81.php
+++ b/tests/Process/DummyProcess81.php
@@ -252,7 +252,7 @@ final class DummyProcess81 extends Process
 
     public function getExitCodeText(): ?string
     {
-        throw new DomainException('Unexpected call.');
+        return 'No explanation, this is a dummy text.';
     }
 
     public function isSuccessful(): bool

--- a/tests/Process/DummyProcessFactory.php
+++ b/tests/Process/DummyProcessFactory.php
@@ -27,11 +27,12 @@ final class DummyProcessFactory implements SymfonyProcessFactory
     public array $processes = [];
 
     public function startProcess(
+        int $index,
         InputStream $inputStream,
         array $command,
         string $workingDirectory,
         ?array $environmentVariables,
-        callable $callback
+        callable $processOutput
     ): Process {
         $process = new DummyProcess(
             $command,
@@ -42,7 +43,7 @@ final class DummyProcessFactory implements SymfonyProcessFactory
         );
         $this->processes[] = $process;
 
-        $process->start($callback);
+        $process->start($processOutput);
 
         ++$this->exitCodeIndex;
 

--- a/tests/Process/DummyProcessFactory.php
+++ b/tests/Process/DummyProcessFactory.php
@@ -21,6 +21,8 @@ final class DummyProcessFactory implements SymfonyProcessFactory
 {
     private int $exitCodeIndex = 0;
 
+    private int $pidSequence = 1000;
+
     /**
      * @var list<DummyProcess>
      */
@@ -34,7 +36,12 @@ final class DummyProcessFactory implements SymfonyProcessFactory
         ?array $environmentVariables,
         callable $processOutput
     ): Process {
+        $pid = $this->pidSequence;
+        ++$this->pidSequence;
+
         $process = new DummyProcess(
+            $index,
+            $pid,
             $command,
             BinomialSum::A000079[$this->exitCodeIndex],
             $workingDirectory,

--- a/tests/Process/FakeProcessFactory.php
+++ b/tests/Process/FakeProcessFactory.php
@@ -20,11 +20,12 @@ use Symfony\Component\Process\Process;
 final class FakeProcessFactory implements SymfonyProcessFactory
 {
     public function startProcess(
+        int $index,
         InputStream $inputStream,
         array $command,
         string $workingDirectory,
         ?array $environmentVariables,
-        callable $callback
+        callable $processOutput
     ): Process {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/Process/FakeProcessLauncherFactory.php
+++ b/tests/Process/FakeProcessLauncherFactory.php
@@ -25,7 +25,7 @@ final class FakeProcessLauncherFactory implements ProcessLauncherFactory
         int $numberOfProcesses,
         int $segmentSize,
         Logger $logger,
-        callable $callback,
+        callable $processOutput,
         callable $tick
     ): ProcessLauncher {
         throw new DomainException('Unexpected call.');

--- a/tests/Process/StandardSymfonyProcessFactoryTest.php
+++ b/tests/Process/StandardSymfonyProcessFactoryTest.php
@@ -27,31 +27,34 @@ final class StandardSymfonyProcessFactoryTest extends TestCase
     {
         $factory = new StandardSymfonyProcessFactory();
 
+        $index = 11;
         $inputStream = new InputStream();
         $command = ['php', 'echo.php'];
         $workingDirectory = __DIR__;
         $environmentVariables = ['TEST_PARALLEL' => '0'];
 
-        $callbackCalled = false;
+        $processOutputCalled = false;
 
         // Do not use a Fake callback here as it would otherwise throw an
         // exception at a random time during cleanup.
-        $callback = static function () use (&$callbackCalled): void {
-            $callbackCalled = true;
+        $processOutput = static function () use (&$processOutputCalled): void {
+            $processOutputCalled = true;
         };
 
         $process = $factory->startProcess(
+            $index,
             $inputStream,
             $command,
             $workingDirectory,
             $environmentVariables,
-            $callback,
+            $processOutput,
         );
 
         self::assertSame("'php' 'echo.php'", $process->getCommandLine());
         self::assertSame($workingDirectory, $process->getWorkingDirectory());
         self::assertSame($environmentVariables, $process->getEnv());
         self::assertTrue($process->isRunning());
-        self::assertFalse($callbackCalled);
+        self::assertNotNull($process->getPid());
+        self::assertFalse($processOutputCalled);
     }
 }

--- a/tests/Process/SymfonyProcessLauncherTest.php
+++ b/tests/Process/SymfonyProcessLauncherTest.php
@@ -190,15 +190,15 @@ final class SymfonyProcessLauncherTest extends TestCase
             2,
             ['item1', 'item2', 'item3', 'item4', 'item5'],
             <<<'TXT'
-                index: 1, pid: , type: dummy; buffer: item1
+                index: 0, pid: 1000, type: dummy; buffer: item1
 
-                index: 1, pid: , type: dummy; buffer: item2
+                index: 0, pid: 1000, type: dummy; buffer: item2
 
-                index: 1, pid: , type: dummy; buffer: item3
+                index: 1, pid: 1001, type: dummy; buffer: item3
 
-                index: 1, pid: , type: dummy; buffer: item4
+                index: 1, pid: 1001, type: dummy; buffer: item4
 
-                index: 1, pid: , type: dummy; buffer: item5
+                index: 1, pid: 1002, type: dummy; buffer: item5
 
 
                 TXT,
@@ -216,15 +216,15 @@ final class SymfonyProcessLauncherTest extends TestCase
             10,
             ['item1', 'item2', 'item3', 'item4', 'item5'],
             <<<'TXT'
-                index: 1, pid: , type: dummy; buffer: item1
+                index: 0, pid: 1000, type: dummy; buffer: item1
 
-                index: 1, pid: , type: dummy; buffer: item2
+                index: 0, pid: 1000, type: dummy; buffer: item2
 
-                index: 1, pid: , type: dummy; buffer: item3
+                index: 0, pid: 1000, type: dummy; buffer: item3
 
-                index: 1, pid: , type: dummy; buffer: item4
+                index: 0, pid: 1000, type: dummy; buffer: item4
 
-                index: 1, pid: , type: dummy; buffer: item5
+                index: 0, pid: 1000, type: dummy; buffer: item5
 
 
                 TXT,
@@ -246,15 +246,15 @@ final class SymfonyProcessLauncherTest extends TestCase
             2,
             ['item1', 'item2', 'item3', 'item4', 'item5'],
             <<<'TXT'
-                index: 1, pid: , type: dummy; buffer: item1
+                index: 0, pid: 1000, type: dummy; buffer: item1
 
-                index: 1, pid: , type: dummy; buffer: item2
+                index: 0, pid: 1000, type: dummy; buffer: item2
 
-                index: 1, pid: , type: dummy; buffer: item3
+                index: 0, pid: 1001, type: dummy; buffer: item3
 
-                index: 1, pid: , type: dummy; buffer: item4
+                index: 0, pid: 1001, type: dummy; buffer: item4
 
-                index: 1, pid: , type: dummy; buffer: item5
+                index: 0, pid: 1002, type: dummy; buffer: item5
 
 
                 TXT,

--- a/tests/Process/SymfonyProcessLauncherTest.php
+++ b/tests/Process/SymfonyProcessLauncherTest.php
@@ -15,6 +15,7 @@ namespace Webmozarts\Console\Parallelization\Process;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Webmozarts\Console\Parallelization\FakeCallable;
 use Webmozarts\Console\Parallelization\Logger\DummyLogger;
 use Webmozarts\Console\Parallelization\Logger\FakeLogger;
@@ -23,6 +24,7 @@ use function explode;
 use function sprintf;
 
 /**
+ * @phpstan-import-type ProcessOutput from ProcessLauncherFactory
  * @covers \Webmozarts\Console\Parallelization\Process\SymfonyProcessLauncher
  *
  * @internal
@@ -56,13 +58,7 @@ final class SymfonyProcessLauncherTest extends TestCase
         $workingDirectory = __DIR__;
         $environmentVariables = ['TEST_SYMFONY_PROCESS' => '1'];
         $logger = new DummyLogger();
-        $callback = static fn (string $type, string $buffer) => $output->writeln(
-            sprintf(
-                'type: %s; buffer: %s',
-                $type,
-                $buffer,
-            ),
-        );
+        $processOutput = self::createProcessOutput($output);
         $processFactory = new DummyProcessFactory();
 
         $launcher = new SymfonyProcessLauncher(
@@ -72,7 +68,7 @@ final class SymfonyProcessLauncherTest extends TestCase
             2,
             2,
             $logger,
-            $callback,
+            $processOutput,
             static function (): void {},
             $processFactory,
         );
@@ -85,7 +81,7 @@ final class SymfonyProcessLauncherTest extends TestCase
             $expectedCommandLine,
             $workingDirectory,
             $environmentVariables,
-            $callback
+            $processOutput
         ): void {
             self::assertSame($expectedCommandLine, $process->getCommandLine());
             self::assertSame($workingDirectory, $process->getWorkingDirectory());
@@ -103,7 +99,7 @@ final class SymfonyProcessLauncherTest extends TestCase
                     ],
                     [
                         'start',
-                        [$callback],
+                        [$processOutput],
                     ],
                 ],
                 $process->calls,
@@ -118,11 +114,11 @@ final class SymfonyProcessLauncherTest extends TestCase
             [
                 [
                     'logChildProcessStarted',
-                    ['php echo.php'],
+                    [0, 1000, 'php echo.php'],
                 ],
                 [
                     'logChildProcessFinished',
-                    [],
+                    [0],
                 ],
             ],
             $logger->records,
@@ -143,13 +139,7 @@ final class SymfonyProcessLauncherTest extends TestCase
     ): void {
         $output = new BufferedOutput();
 
-        $callback = static fn (string $type, string $buffer) => $output->writeln(
-            sprintf(
-                'type: %s; buffer: %s',
-                $type,
-                $buffer,
-            ),
-        );
+        $processOutput = self::createProcessOutput($output);
         $processFactory = new DummyProcessFactory();
         $numberOfTicksRecorded = 0;
 
@@ -160,7 +150,7 @@ final class SymfonyProcessLauncherTest extends TestCase
             $numberOfProcesses,
             $segmentSize,
             new DummyLogger(),
-            $callback,
+            $processOutput,
             static function () use (&$numberOfTicksRecorded): void {
                 ++$numberOfTicksRecorded;
             },
@@ -200,15 +190,15 @@ final class SymfonyProcessLauncherTest extends TestCase
             2,
             ['item1', 'item2', 'item3', 'item4', 'item5'],
             <<<'TXT'
-                type: dummy; buffer: item1
+                index: 1, pid: , type: dummy; buffer: item1
 
-                type: dummy; buffer: item2
+                index: 1, pid: , type: dummy; buffer: item2
 
-                type: dummy; buffer: item3
+                index: 1, pid: , type: dummy; buffer: item3
 
-                type: dummy; buffer: item4
+                index: 1, pid: , type: dummy; buffer: item4
 
-                type: dummy; buffer: item5
+                index: 1, pid: , type: dummy; buffer: item5
 
 
                 TXT,
@@ -226,15 +216,15 @@ final class SymfonyProcessLauncherTest extends TestCase
             10,
             ['item1', 'item2', 'item3', 'item4', 'item5'],
             <<<'TXT'
-                type: dummy; buffer: item1
+                index: 1, pid: , type: dummy; buffer: item1
 
-                type: dummy; buffer: item2
+                index: 1, pid: , type: dummy; buffer: item2
 
-                type: dummy; buffer: item3
+                index: 1, pid: , type: dummy; buffer: item3
 
-                type: dummy; buffer: item4
+                index: 1, pid: , type: dummy; buffer: item4
 
-                type: dummy; buffer: item5
+                index: 1, pid: , type: dummy; buffer: item5
 
 
                 TXT,
@@ -256,15 +246,15 @@ final class SymfonyProcessLauncherTest extends TestCase
             2,
             ['item1', 'item2', 'item3', 'item4', 'item5'],
             <<<'TXT'
-                type: dummy; buffer: item1
+                index: 1, pid: , type: dummy; buffer: item1
 
-                type: dummy; buffer: item2
+                index: 1, pid: , type: dummy; buffer: item2
 
-                type: dummy; buffer: item3
+                index: 1, pid: , type: dummy; buffer: item3
 
-                type: dummy; buffer: item4
+                index: 1, pid: , type: dummy; buffer: item4
 
-                type: dummy; buffer: item5
+                index: 1, pid: , type: dummy; buffer: item5
 
 
                 TXT,
@@ -276,5 +266,21 @@ final class SymfonyProcessLauncherTest extends TestCase
             6,
             7,
         ];
+    }
+
+    /**
+     * @return ProcessOutput
+     */
+    private static function createProcessOutput(OutputInterface $output): callable
+    {
+        return static fn (int $index, ?int $pid, string $type, string $buffer) => $output->writeln(
+            sprintf(
+                'index: %d, pid: %s, type: %s; buffer: %s',
+                $index,
+                $pid,
+                $type,
+                $buffer,
+            ),
+        );
     }
 }


### PR DESCRIPTION
Technically should only be BC breaks if coming from the previous beta _and_ implementing your own logger.

Change the Logger API to pass around the child process index & PID.