### PR TITLE
Rename logger methods

### DIFF
--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -37,17 +37,17 @@ interface Logger
     /**
      * @param 0|positive-int|null $numberOfItems
      */
-    public function startProgress(?int $numberOfItems): void;
+    public function logStart(?int $numberOfItems): void;
 
     /**
      * @param positive-int|0 $steps
      */
-    public function advance(int $steps = 1): void;
+    public function logAdvance(int $steps = 1): void;
 
     /**
      * @param string $itemName Name of the item; Already in the singular or plural form.
      */
-    public function finish(string $itemName): void;
+    public function logFinish(string $itemName): void;
 
     public function logItemProcessingFailed(string $item, Throwable $throwable): void;
 
@@ -56,9 +56,9 @@ interface Logger
      *                            with the Symfony command name which is just an element of
      *                            the command.
      */
-    public function logCommandStarted(string $commandName): void;
+    public function logChildProcessStarted(string $commandName): void;
 
-    public function logCommandFinished(): void;
+    public function logChildProcessFinished(): void;
 
     /**
      * Logs the "unexpected" child output. By unexpected is meant that the main
@@ -67,5 +67,5 @@ interface Logger
      *
      * @param string $buffer Child process output.
      */
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void;
+    public function logUnexpectedChildProcessOutput(string $buffer, string $progressSymbol): void;
 }

--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -28,17 +28,17 @@ final class NullLogger implements Logger
         // Do nothing.
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         // Do nothing.
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         // Do nothing.
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         // Do nothing.
     }
@@ -48,17 +48,17 @@ final class NullLogger implements Logger
         // Do nothing.
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(string $commandName): void
     {
         // Do nothing.
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(): void
     {
         // Do nothing.
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(string $buffer, string $progressSymbol): void
     {
         // Do nothing.
     }

--- a/src/Logger/StandardLogger.php
+++ b/src/Logger/StandardLogger.php
@@ -85,7 +85,7 @@ final class StandardLogger implements Logger
         $this->output->writeln('');
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         Assert::false(
             isset($this->progressBar),
@@ -98,7 +98,7 @@ final class StandardLogger implements Logger
         );
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         Assert::true(
             isset($this->progressBar),
@@ -108,7 +108,7 @@ final class StandardLogger implements Logger
         $this->progressBar->advance($steps);
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         Assert::true(
             isset($this->progressBar),
@@ -138,17 +138,17 @@ final class StandardLogger implements Logger
         ));
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(string $commandName): void
     {
         $this->logger->debug('Command started: '.$commandName);
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(): void
     {
         $this->logger->debug('Command finished');
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(string $buffer, string $progressSymbol): void
     {
         $this->output->writeln('');
         $this->output->writeln(sprintf(

--- a/src/ParallelExecutor.php
+++ b/src/ParallelExecutor.php
@@ -231,7 +231,7 @@ final class ParallelExecutor
             $shouldSpawnChildProcesses,
         );
 
-        $logger->startProgress($numberOfItems);
+        $logger->logStart($numberOfItems);
 
         if ($shouldSpawnChildProcesses) {
             $exitCode = $this
@@ -248,11 +248,11 @@ final class ParallelExecutor
                 $input,
                 $output,
                 $logger,
-                static fn () => $logger->advance(),
+                static fn () => $logger->logAdvance(),
             );
         }
 
-        $logger->finish($itemName);
+        $logger->logFinish($itemName);
 
         ($this->runAfterLastCommand)($input, $output);
 
@@ -372,10 +372,10 @@ final class ParallelExecutor
 
         // Display unexpected output
         if ($charactersCount !== mb_strlen($buffer)) {
-            $logger->logUnexpectedOutput($buffer, $progressSymbol);
+            $logger->logUnexpectedChildProcessOutput($buffer, $progressSymbol);
         }
 
-        $logger->advance($charactersCount);
+        $logger->logAdvance($charactersCount);
     }
 
     private static function validateBatchSize(int $batchSize): void

--- a/src/Process/SymfonyProcessLauncher.php
+++ b/src/Process/SymfonyProcessLauncher.php
@@ -163,7 +163,7 @@ final class SymfonyProcessLauncher implements ProcessLauncher
             $this->callback,
         );
 
-        $this->logger->logCommandStarted($process->getCommandLine());
+        $this->logger->logChildProcessStarted($process->getCommandLine());
 
         $this->runningProcesses[] = $process;
     }
@@ -192,7 +192,7 @@ final class SymfonyProcessLauncher implements ProcessLauncher
      */
     private function freeProcess(int $index, Process $process): int
     {
-        $this->logger->logCommandFinished();
+        $this->logger->logChildProcessFinished();
 
         unset($this->runningProcesses[$index]);
 

--- a/tests/Logger/DummyLogger.php
+++ b/tests/Logger/DummyLogger.php
@@ -34,7 +34,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -42,7 +42,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -50,7 +50,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -66,7 +66,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(string $commandName): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -74,7 +74,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(): void
     {
         $this->records[] = [
             __FUNCTION__,
@@ -82,7 +82,7 @@ final class DummyLogger implements Logger
         ];
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(string $buffer, string $progressSymbol): void
     {
         $this->records[] = [
             __FUNCTION__,

--- a/tests/Logger/FakeLogger.php
+++ b/tests/Logger/FakeLogger.php
@@ -29,17 +29,17 @@ final class FakeLogger implements Logger
         throw new DomainException('Unexpected call.');
     }
 
-    public function startProgress(?int $numberOfItems): void
+    public function logStart(?int $numberOfItems): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function advance(int $steps = 1): void
+    public function logAdvance(int $steps = 1): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function finish(string $itemName): void
+    public function logFinish(string $itemName): void
     {
         throw new DomainException('Unexpected call.');
     }
@@ -49,17 +49,17 @@ final class FakeLogger implements Logger
         throw new DomainException('Unexpected call.');
     }
 
-    public function logCommandStarted(string $commandName): void
+    public function logChildProcessStarted(string $commandName): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function logCommandFinished(): void
+    public function logChildProcessFinished(): void
     {
         throw new DomainException('Unexpected call.');
     }
 
-    public function logUnexpectedOutput(string $buffer, string $progressSymbol): void
+    public function logUnexpectedChildProcessOutput(string $buffer, string $progressSymbol): void
     {
         throw new DomainException('Unexpected call.');
     }

--- a/tests/Logger/StandardLoggerTest.php
+++ b/tests/Logger/StandardLoggerTest.php
@@ -342,7 +342,7 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_can_log_the_start_of_the_processing(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
 
         $expected = <<<'TXT'
               0/10 [>---------------------------]   0%
@@ -353,20 +353,20 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_cannot_start_an_already_started_process(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot start the progress: already started.');
 
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
     }
 
     public function test_it_can_log_the_progress_of_the_processing(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
         $this->output->fetch();
 
-        $this->logger->advance();
+        $this->logger->logAdvance();
 
         $expected = <<<'TXT'
 
@@ -381,15 +381,15 @@ final class StandardLoggerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected the progress to be started.');
 
-        $this->logger->advance();
+        $this->logger->logAdvance();
     }
 
     public function test_it_can_log_the_progress_of_the_processing_of_multiple_items(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
         $this->output->fetch();
 
-        $this->logger->advance(4);
+        $this->logger->logAdvance(4);
 
         $expected = <<<'TXT'
 
@@ -401,10 +401,10 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_can_log_the_end_of_the_processing(): void
     {
-        $this->logger->startProgress(10);
+        $this->logger->logStart(10);
         $this->output->fetch();
 
-        $this->logger->finish('tokens');
+        $this->logger->logFinish('tokens');
 
         $expected = <<<'TXT'
 
@@ -422,16 +422,16 @@ final class StandardLoggerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected the progress to be started.');
 
-        $this->logger->finish('tokens');
+        $this->logger->logFinish('tokens');
     }
 
     public function test_it_can_log_the_unexpected_output_of_a_child_process(): void
     {
-        $this->logger->startProgress(10);
-        $this->logger->advance(4);
+        $this->logger->logStart(10);
+        $this->logger->logAdvance(4);
         $this->output->fetch();
 
-        $this->logger->logUnexpectedOutput(
+        $this->logger->logUnexpectedChildProcessOutput(
             'An error occurred.',
             self::ADVANCEMENT_CHARACTER,
         );
@@ -449,11 +449,11 @@ final class StandardLoggerTest extends TestCase
 
     public function test_it_removes_the_progress_character_of_the_unexpected_output_of_a_child_process(): void
     {
-        $this->logger->startProgress(10);
-        $this->logger->advance(4);
+        $this->logger->logStart(10);
+        $this->logger->logAdvance(4);
         $this->output->fetch();
 
-        $this->logger->logUnexpectedOutput(
+        $this->logger->logUnexpectedChildProcessOutput(
             'An error'.self::ADVANCEMENT_CHARACTER.' occurred.',
             self::ADVANCEMENT_CHARACTER,
         );
@@ -473,7 +473,7 @@ final class StandardLoggerTest extends TestCase
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-        $this->logger->logCommandStarted('/path/to/bin/console foo:bar --child');
+        $this->logger->logChildProcessStarted('/path/to/bin/console foo:bar --child');
 
         $expected = <<<'TXT'
             [debug] Command started: /path/to/bin/console foo:bar --child
@@ -487,7 +487,7 @@ final class StandardLoggerTest extends TestCase
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-        $this->logger->logCommandFinished();
+        $this->logger->logChildProcessFinished();
 
         $expected = <<<'TXT'
             [debug] Command finished

--- a/tests/ParallelExecutorTest.php
+++ b/tests/ParallelExecutorTest.php
@@ -726,35 +726,35 @@ final class ParallelExecutorTest extends TestCase
                 ],
             ],
             [
-                'startProgress',
+                'logStart',
                 [5],
             ],
             [
-                'advance',
+                'logAdvance',
                 [1],
             ],
             [
-                'logUnexpectedOutput',
+                'logUnexpectedChildProcessOutput',
                 ['FOO', $progressSymbol],
             ],
             [
-                'advance',
+                'logAdvance',
                 [0],
             ],
             [
-                'advance',
+                'logAdvance',
                 [1],
             ],
             [
-                'advance',
+                'logAdvance',
                 [3],
             ],
             [
-                'advance',
+                'logAdvance',
                 [1],
             ],
             [
-                'finish',
+                'logFinish',
                 ['items'],
             ],
         ];
@@ -885,11 +885,11 @@ final class ParallelExecutorTest extends TestCase
                     ],
                 ],
                 [
-                    'startProgress',
+                    'logStart',
                     [3],
                 ],
                 [
-                    'finish',
+                    'logFinish',
                     ['items'],
                 ],
             ],
@@ -979,23 +979,23 @@ final class ParallelExecutorTest extends TestCase
                     ],
                 ],
                 [
-                    'startProgress',
+                    'logStart',
                     [3],
                 ],
                 [
-                    'advance',
+                    'logAdvance',
                     [],
                 ],
                 [
-                    'advance',
+                    'logAdvance',
                     [],
                 ],
                 [
-                    'advance',
+                    'logAdvance',
                     [],
                 ],
                 [
-                    'finish',
+                    'logFinish',
                     ['items'],
                 ],
             ],

--- a/tests/Process/SymfonyProcessLauncherTest.php
+++ b/tests/Process/SymfonyProcessLauncherTest.php
@@ -117,11 +117,11 @@ final class SymfonyProcessLauncherTest extends TestCase
         self::assertSame(
             [
                 [
-                    'logCommandStarted',
+                    'logChildProcessStarted',
                     ['php echo.php'],
                 ],
                 [
-                    'logCommandFinished',
+                    'logChildProcessFinished',
                     [],
                 ],
             ],


### PR DESCRIPTION
Technically should only be BC breaks if coming from the previous beta and implementing your own logger