### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/EnvironmentVariables.php
+++ b/tests/EnvironmentVariables.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization;

--- a/tests/EnvironmentVariables.php
+++ b/tests/EnvironmentVariables.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization;
+
+use function array_key_exists;
+use function array_keys;
+use function array_map;
+use function Safe\putenv;
+
+final class EnvironmentVariables
+{
+    /**
+     * @param array<string, string> $environmentVariables
+     *
+     * @return callable():void Cleanup method: restores the previous state.
+     */
+    public static function setVariables(array $environmentVariables): callable
+    {
+        $restoreEnvironmentVariables = array_map(
+            static fn (string $name) => self::setVariable($name, $environmentVariables[$name]),
+            array_keys($environmentVariables),
+        );
+
+        return static function () use ($restoreEnvironmentVariables): void {
+            foreach ($restoreEnvironmentVariables as $restoreEnvironmentVariable) {
+                $restoreEnvironmentVariable();
+            }
+        };
+    }
+
+    /**
+     * @return callable():void
+     */
+    private static function setVariable(string $name, string $value): callable
+    {
+        if (array_key_exists($name, $_SERVER)) {
+            $previousValue = $_SERVER[$name];
+
+            $restoreServer = static fn () => $_SERVER[$name] = $previousValue;
+        } else {
+            $restoreServer = static function () use ($name): void {
+                unset($_SERVER[$name]);
+            };
+        }
+
+        if (array_key_exists($name, $_ENV)) {
+            $previousValue = $_ENV[$name];
+
+            $restoreEnv = static fn () => $_SERVER[$name] = $previousValue;
+        } else {
+            $restoreEnv = static function () use ($name): void {
+                unset($_ENV[$name]);
+            };
+        }
+
+        putenv($name.'='.$value);
+        $_SERVER[$name] = $value;
+        $_ENV[$name] = $value;
+
+        return static function () use ($restoreServer, $restoreEnv, $name): void {
+            putenv($name.'=');
+            $restoreServer();
+            $restoreEnv();
+        };
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/Fixtures/Command/ImportMoviesCommand.php
+++ b/tests/Fixtures/Command/ImportMoviesCommand.php
@@ -85,8 +85,8 @@ final class ImportMoviesCommand extends Command
             $commandDefinition,
             $errorHandler,
         )
-            ->withBatchSize(1)
-            ->withSegmentSize(1)
+            ->withBatchSize(2)
+            ->withSegmentSize(2)
             ->withRunBeforeFirstCommand(
                 fn () => $this->logger->recordFirstCommand(),
             )
@@ -104,7 +104,6 @@ final class ImportMoviesCommand extends Command
 
     protected function runSingleCommand(string $movieFileName, InputInterface $input, OutputInterface $output): void
     {
-        sleep(2);
         $this->logger->recordSingleCommand(
             $movieFileName,
             $this->batchMovies[$movieFileName],

--- a/tests/Fixtures/Command/ImportMoviesCommand.php
+++ b/tests/Fixtures/Command/ImportMoviesCommand.php
@@ -85,8 +85,8 @@ final class ImportMoviesCommand extends Command
             $commandDefinition,
             $errorHandler,
         )
-            ->withBatchSize(2)
-            ->withSegmentSize(2)
+            ->withBatchSize(1)
+            ->withSegmentSize(1)
             ->withRunBeforeFirstCommand(
                 fn () => $this->logger->recordFirstCommand(),
             )
@@ -104,6 +104,7 @@ final class ImportMoviesCommand extends Command
 
     protected function runSingleCommand(string $movieFileName, InputInterface $input, OutputInterface $output): void
     {
+        sleep(2);
         $this->logger->recordSingleCommand(
             $movieFileName,
             $this->batchMovies[$movieFileName],

--- a/tests/Integration/OutputNormalizer.php
+++ b/tests/Integration/OutputNormalizer.php
@@ -15,15 +15,102 @@ use const PHP_EOL;
 
 final class OutputNormalizer
 {
-    private function getOutput(CommandTester $commandTester): string
+    public static function normalizeMemoryUsage(string $output): string
     {
-        $output = $commandTester->getDisplay(true);
-
-        $output = preg_replace(
+        return preg_replace(
             '/\d+(\.\d+)? ([A-Z]i)?B/',
             '10.0 MiB',
             $output,
         );
+    }
+
+    public static function normalizeProgressBarTimeTaken(string $output): string
+    {
+        $output = str_replace(
+            '< 1 sec',
+            '10 secs',
+            $output,
+        );
+
+        $output = preg_replace(
+            '/\d+ secs?/',
+            '10 secs',
+            $output,
+        );
+
+        $replaceMap = [
+            '%  10 secs' => '% 10 secs',
+            'secs  10.0 MiB' => 'secs 10.0 MiB',
+            ']  10 secs' => '] 10 secs',
+            PHP_EOL => "\n",
+            (new PhpExecutableFinder())->find() => '/path/to/php',
+            getcwd() => '/path/to/work-dir',
+        ];
+
+        return str_replace(
+            array_keys($replaceMap),
+            $replaceMap,
+            $output,
+        );
+    }
+
+    public static function normalizePhpExecutablePath(string $output): string
+    {
+        $replaceMap = [
+            (new PhpExecutableFinder())->find() => '/path/to/php',
+            getcwd() => '/path/to/work-dir',
+        ];
+
+        $output = self::normalizeConsolePath($output);
+
+        return str_replace(
+            array_keys($replaceMap),
+            $replaceMap,
+            $output,
+        );
+    }
+
+    public static function normalizeProjectPath(string $output): string
+    {
+        $replaceMap = [
+            (new PhpExecutableFinder())->find() => '/path/to/php',
+            getcwd() => '/path/to/work-dir',
+        ];
+
+        $output = self::normalizeConsolePath($output);
+
+        return str_replace(
+            array_keys($replaceMap),
+            $replaceMap,
+            $output,
+        );
+    }
+
+    public static function normalizeLineReturns(string $output): string
+    {
+        $replaceMap = [
+            (new PhpExecutableFinder())->find() => '/path/to/php',
+            getcwd() => '/path/to/work-dir',
+        ];
+
+        $output = self::normalizeConsolePath($output);
+
+        return str_replace(
+            array_keys($replaceMap),
+            $replaceMap,
+            $output,
+        );
+    }
+
+    private function getOutput(CommandTester $commandTester): string
+    {
+        $output = $commandTester->getDisplay(true);
+
+//        $output = preg_replace(
+//            '/\d+(\.\d+)? ([A-Z]i)?B/',
+//            '10.0 MiB',
+//            $output,
+//        );
 
         $output = str_replace(
             '< 1 sec',
@@ -64,7 +151,7 @@ final class OutputNormalizer
         );
     }
 
-    private static function normalizeIntermediateFixedProgressBars(
+    public static function removeIntermediateFixedProgressBars(
         string $output,
         int $expectedNumberOfItems = 5
     ): string {
@@ -81,7 +168,7 @@ final class OutputNormalizer
         );
     }
 
-    public static function normalizeIntermediateDynamicProgressBars(string $output): string
+    public static function removeIntermediateNonFixedProgressBars(string $output): string
     {
         $output = preg_replace(
             '# *?[1-4] \[[>-]+\]  ?10 secs 10.0 MiB\n#',

--- a/tests/Integration/OutputNormalizer.php
+++ b/tests/Integration/OutputNormalizer.php
@@ -42,6 +42,7 @@ final class OutputNormalizer
         $replaceMap = [
             '%  10 secs' => '% 10 secs',
             'secs  10.0 MiB' => 'secs 10.0 MiB',
+            ']  10 secs' => '] 10 secs',
         ];
 
         return str_replace(

--- a/tests/Integration/OutputNormalizer.php
+++ b/tests/Integration/OutputNormalizer.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Integration;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\PhpExecutableFinder;
+use function array_keys;
+use function getcwd;
+use function preg_replace;
+use function sprintf;
+use function str_replace;
+use const PHP_EOL;
+
+final class OutputNormalizer
+{
+    private function getOutput(CommandTester $commandTester): string
+    {
+        $output = $commandTester->getDisplay(true);
+
+        $output = preg_replace(
+            '/\d+(\.\d+)? ([A-Z]i)?B/',
+            '10.0 MiB',
+            $output,
+        );
+
+        $output = str_replace(
+            '< 1 sec',
+            '10 secs',
+            $output,
+        );
+
+        $output = preg_replace(
+            '/\d+ secs?/',
+            '10 secs',
+            $output,
+        );
+
+        $replaceMap = [
+            '%  10 secs' => '% 10 secs',
+            'secs  10.0 MiB' => 'secs 10.0 MiB',
+            ']  10 secs' => '] 10 secs',
+            PHP_EOL => "\n",
+            (new PhpExecutableFinder())->find() => '/path/to/php',
+            getcwd() => '/path/to/work-dir',
+        ];
+
+        $output = self::normalizeConsolePath($output);
+
+        return str_replace(
+            array_keys($replaceMap),
+            $replaceMap,
+            $output,
+        );
+    }
+
+    private static function normalizeConsolePath(string $output): string
+    {
+        return preg_replace(
+            '~'.getcwd().'.+?console~',
+            '/path/to/work-dir/bin/console',
+            $output,
+        );
+    }
+
+    private static function normalizeIntermediateFixedProgressBars(
+        string $output,
+        int $expectedNumberOfItems = 5
+    ): string {
+        $intermediateItemRange = sprintf(
+            '[1-%d]/%d',
+            $expectedNumberOfItems - 1,
+            $expectedNumberOfItems,
+        );
+
+        return preg_replace(
+            '# *?'.$intermediateItemRange.' \[[=>-]+\]  \d+% 10 secs/10 secs 10.0 MiB\n#',
+            '',
+            $output,
+        );
+    }
+
+    public static function normalizeIntermediateDynamicProgressBars(string $output): string
+    {
+        $output = preg_replace(
+            '# *?[1-4] \[[>-]+\]  ?10 secs 10.0 MiB\n#',
+            '',
+            $output,
+        );
+
+        return str_replace(
+            '\[[->]+?\]',
+            '[----->----------------------]',
+            $output,
+        );
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/Integration/OutputNormalizer.php
+++ b/tests/Integration/OutputNormalizer.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Integration;
 
 use Symfony\Component\Process\PhpExecutableFinder;
+use function array_keys;
+use function array_values;
 use function bin2hex;
 use function getcwd;
 use function preg_match;
@@ -23,6 +25,32 @@ use function str_replace;
 
 final class OutputNormalizer
 {
+    public static function normalize(string $output): string
+    {
+        $output = self::normalizeProgressBarTimeTaken(
+            self::normalizeMemoryUsage(
+                self::normalizeProjectPath(
+                    self::normalizePhpExecutablePath(
+                        self::normalizeLineReturns($output),
+                    ),
+                ),
+            ),
+        );
+
+        // We may still have some unstable cases due to extra spacing added
+        // depending on the overall result
+        $replaceMap = [
+            '%  10 secs' => '% 10 secs',
+            'secs  10.0 MiB' => 'secs 10.0 MiB',
+        ];
+
+        return str_replace(
+            array_keys($replaceMap),
+            array_values($replaceMap),
+            $output,
+        );
+    }
+
     public static function normalizeMemoryUsage(string $output): string
     {
         return preg_replace(

--- a/tests/Integration/OutputNormalizerTest.php
+++ b/tests/Integration/OutputNormalizerTest.php
@@ -396,4 +396,62 @@ final class OutputNormalizerTest extends TestCase
                 TXT,
         ];
     }
+
+    /**
+     * @dataProvider outputProvider
+     */
+    public function test_it_can_normalize_output(string $output, string $expected): void
+    {
+        $actual = OutputNormalizer::normalize($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function outputProvider(): iterable
+    {
+        yield 'standard non-fixed sized progress bar line' => [
+            ' 4 [--->------------------------] < 1 sec 8.0 MiB',
+            ' 4 [--->------------------------] 10 secs 10.0 MiB',
+        ];
+
+        yield 'standard non-fixed sized progress bar line with extra padding' => [
+            '     4 [--->------------------------] < 1 sec 8.0 MiB',
+            '     4 [--->------------------------] 10 secs 10.0 MiB',
+        ];
+
+        yield 'standard non-fixed sized progress bar line with extra content no spacing' => [
+            ' 4 [--->------------------------] < 1 sec 8.0 MiB[debug] Command started:',
+            ' 4 [--->------------------------] 10 secs 10.0 MiB[debug] Command started:',
+        ];
+
+        yield 'standard non-fixed sized progress bar line with extra content with spacing' => [
+            ' 4 [--->------------------------] < 1 sec 8.0 MiB [debug] Command started:',
+            ' 4 [--->------------------------] 10 secs 10.0 MiB [debug] Command started:',
+        ];
+
+        yield 'standard fixed sized progress bar line' => [
+            ' 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB',
+            ' 0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB',
+        ];
+
+        yield 'standard fixed sized progress bar line with extra padding' => [
+            '     0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB',
+            '     0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB',
+        ];
+
+        yield 'standard fixed sized progress bar line with extra content no spacing' => [
+            ' 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB[debug] Command started:',
+            ' 0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB[debug] Command started:',
+        ];
+
+        yield 'standard fixed sized progress bar line with extra content with spacing' => [
+            ' 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB [debug] Command started:',
+            ' 0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB [debug] Command started:',
+        ];
+
+        yield 'standard line with extra spacing' => [
+            ' 5/5 [============================] 100%  1 sec/1 sec  14.0 MiB[debug] Command finished',
+            ' 5/5 [============================] 100% 10 secs/10 secs 10.0 MiB[debug] Command finished',
+        ];
+    }
 }

--- a/tests/Integration/OutputNormalizerTest.php
+++ b/tests/Integration/OutputNormalizerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Webmozarts\Console\Parallelization\Integration\OutputNormalizer
+ */
+final class OutputNormalizerTest extends TestCase
+{
+    public function test_it_can_()
+    {
+        
+    }
+}

--- a/tests/Integration/OutputNormalizerTest.php
+++ b/tests/Integration/OutputNormalizerTest.php
@@ -5,14 +5,341 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Integration;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Webmozarts\Console\Parallelization\EnvironmentVariables;
+use function Safe\getcwd;
 
 /**
  * @covers \Webmozarts\Console\Parallelization\Integration\OutputNormalizer
  */
 final class OutputNormalizerTest extends TestCase
 {
-    public function test_it_can_()
+    /**
+     * @dataProvider memoryUsageProvider
+     */
+    public function test_it_can_normalize_the_memory_usage(string $output, string $expected): void
     {
-        
+        $actual = OutputNormalizer::normalizeMemoryUsage($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function memoryUsageProvider(): iterable
+    {
+        yield 'single digit' => [
+            '8.0 MiB',
+            '10.0 MiB',
+        ];
+
+        yield 'several digits' => [
+            '231.0 MiB',
+            '10.0 MiB',
+        ];
+
+        yield 'with spaces' => [
+            ' 8.0 MiB ',
+            ' 10.0 MiB ',
+        ];
+
+        yield 'fixed size bar' => [
+            ' 4/5 [======================>-----]  80%  1 sec/1 sec  8.0 MiB ',
+            ' 4/5 [======================>-----]  80%  1 sec/1 sec  10.0 MiB ',
+        ];
+
+        yield 'non-fixed size bar' => [
+            ' 5 [----->----------------------] < 1 sec 8.0 MiB ',
+            ' 5 [----->----------------------] < 1 sec 10.0 MiB ',
+        ];
+    }
+
+    /**
+     * @dataProvider progressBarTimeTakenProvider
+     */
+    public function test_it_can_normalize_the_time_taken_for_a_progress_bar(
+        string $output,
+        string $expected
+    ): void {
+        $actual = OutputNormalizer::normalizeProgressBarTimeTaken($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function progressBarTimeTakenProvider(): iterable
+    {
+        yield '[non-fixed size bar] less than a second' => [
+            ' < 1 sec ',
+            ' 10 secs ',
+        ];
+
+        yield '[non-fixed size bar] single digit' => [
+            ' 7 secs ',
+            ' 10 secs ',
+        ];
+
+        yield '[non-fixed size bar] multiple digits' => [
+            ' 17 secs ',
+            ' 10 secs ',
+        ];
+
+        yield '[fixed size bar] less than a second' => [
+            ' < 1 sec/< 1 sec',
+            ' 10 secs/10 secs',
+        ];
+
+        yield '[fixed size bar] single digit' => [
+            ' 4 secs/7 secs',
+            ' 10 secs/10 secs ',
+        ];
+
+        yield '[fixed size bar] mixed' => [
+            ' < 1 sec/18 secs',
+            ' 10 secs/10 secs ',
+        ];
+
+        yield 'fixed size bar' => [
+            ' 4/5 [======================>-----]  80%  4 secs/10 secs  8.0 MiB ',
+            ' 4/5 [======================>-----]  80%  10 secs/10 secs  8.0 MiB ',
+        ];
+
+        yield 'non-fixed size bar' => [
+            ' 5 [----->----------------------] 4 secs 8.0 MiB ',
+            ' 5 [----->----------------------] 10 secs 8.0 MiB ',
+        ];
+    }
+
+    /**
+     * @dataProvider phpExecutableProvider
+     */
+    public function test_it_can_normalize_the_php_executable_path(
+        string $output,
+        array $environmentVariables,
+        string $expected
+    ): void {
+        $cleanup = EnvironmentVariables::setVariables($environmentVariables);
+
+        $actual = OutputNormalizer::normalizePhpExecutablePath($output);
+
+        $cleanup();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function phpExecutableProvider(): iterable
+    {
+        $environmentVariables = [
+            'PHP_BINARY' => 'Users/myaccount/.phpbrew/php/php-9.3.2/bin/php',
+        ];
+
+        yield 'escaped path' => [
+            ' \'/Users/myaccount/.phpbrew/php/php-9.3.2/bin/php\' ',
+            $environmentVariables,
+            ' \'/path/to/php\' ',
+        ];
+
+        yield 'non escaped-path' => [
+            ' /Users/myaccount/.phpbrew/php/php-9.3.2/bin/php ',
+            $environmentVariables,
+            ' /path/to/php ',
+        ];
+
+        yield 'escaped path longer path' => [
+            ' \'/Users/myaccount/.phpbrew/php/php-9.3.2/bin/php/phar\' ',
+            $environmentVariables,
+            ' \'/path/to/php/phar\' ',
+        ];
+    }
+
+    /**
+     * @dataProvider normalizePathProvider
+     */
+    public function test_it_can_normalize_the_project_path(
+        string $output,
+        string $expected
+    ): void {
+        $actual = OutputNormalizer::normalizeProjectPath($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function normalizePathProvider(): iterable
+    {
+        $cwd = getcwd();
+
+        yield 'escaped path' => [
+            ' \'/'.$cwd.'\' ',
+            ' \'/path/to/work-dir\' ',
+        ];
+
+        yield 'non escaped-path' => [
+            ' '.$cwd.' ',
+            ' /path/to/work-dir ',
+        ];
+
+        yield 'escaped path longer path' => [
+            ' \''.$cwd.'/bin/foo.php\' ',
+            ' \'/path/to/work-dir/bin/foo.php\' ',
+        ];
+    }
+
+    /**
+     * @dataProvider lineReturnsProvider
+     */
+    public function test_it_can_normalize_line_returns(
+        string $output,
+        string $expected
+    ): void {
+        $actual = OutputNormalizer::normalizeLineReturns($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function lineReturnsProvider(): iterable
+    {
+        yield 'linux return paths' => [
+            <<<'TXT'
+            
+            
+            TXT,
+            ' \'/path/to/work-dir\' ',
+        ];
+
+        yield 'windows return paths' => [
+            "\r\n  \r\n",
+            "\n  \n",
+        ];
+    }
+
+    /**
+     * @dataProvider fixedSizedProgressBarsProvider
+     */
+    public function test_it_can_normalize_fixed_sized_progress_bars(
+        string $output,
+        string $expected
+    ): void {
+        $actual = OutputNormalizer::removeIntermediateFixedProgressBars($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function fixedSizedProgressBarsProvider(): iterable
+    {
+        yield 'single intermediate line' => [
+            ' 4/5 [======================>-----]  80%  1 sec/1 sec  10.0 MiB',
+            '',
+        ];
+
+        yield 'single intermediate line with trailing content' => [
+            ' 4/5 [======================>-----]  80%  1 sec/1 sec  10.0 MiB [debug] smth',
+            ' [debug] smth',
+        ];
+
+        yield 'nominal without extra content' => [
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             1/5 [=====>----------------------]  20% 2 secs/10 secs 10.0 MiB
+             2/5 [===========>----------------]  40% 4 secs/10 secs 10.0 MiB
+             3/5 [================>-----------]  60% 6 secs/10 secs 10.0 MiB
+             4/5 [======================>-----]  80% 8 secs/10 secs 10.0 MiB
+             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+        ];
+
+        yield 'nominal with extra content' => [
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             1/5 [=====>----------------------]  20% 2 secs/10 secs 10.0 MiB [debug] smth1
+            [debug] smth2
+             2/5 [===========>----------------]  40% 4 secs/10 secs 10.0 MiB
+             3/5 [================>-----------]  60% 6 secs/10 secs 10.0 MiB[debug] smth3
+             4/5 [======================>-----]  80% 8 secs/10 secs 10.0 MiB
+             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             [debug] smth1
+            [debug] smth2
+            [debug] smth3
+             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+        ];
+    }
+
+    /**
+     * @dataProvider nonFixedSizedProgressBarsProvider
+     */
+    public function test_it_can_normalize_non_fixed_sized_progress_bars(
+        string $output,
+        string $expected
+    ): void {
+        $actual = OutputNormalizer::removeIntermediateNonFixedProgressBars($output);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function nonFixedSizedProgressBarsProvider(): iterable
+    {
+        yield 'single intermediate line' => [
+            ' 4/5 [---------------------->-----]  80%  1 sec/1 sec  10.0 MiB',
+            '',
+        ];
+
+        yield 'single intermediate line with trailing content' => [
+            ' 4/5 [---------------------->-----]  80%  1 sec/1 sec  10.0 MiB [debug] smth',
+            ' [debug] smth',
+        ];
+
+        yield 'nominal without extra content' => [
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             1/5 [----->----------------------]  20% 2 secs/10 secs 10.0 MiB
+             2/5 [----------->----------------]  40% 4 secs/10 secs 10.0 MiB
+             3/5 [---------------->-----------]  60% 6 secs/10 secs 10.0 MiB
+             4/5 [---------------------->-----]  80% 8 secs/10 secs 10.0 MiB
+             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+        ];
+
+        yield 'nominal with extra content' => [
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             1/5 [----->----------------------]  20% 2 secs/10 secs 10.0 MiB [debug] smth1
+            [debug] smth2
+             2/5 [----------->----------------]  40% 4 secs/10 secs 10.0 MiB
+             3/5 [---------------->-----------]  60% 6 secs/10 secs 10.0 MiB[debug] smth3
+             4/5 [---------------------->-----]  80% 8 secs/10 secs 10.0 MiB
+             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+            <<<'TXT'
+            
+             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+             [debug] smth1
+            [debug] smth2
+            [debug] smth3
+             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
+
+            TXT,
+        ];
     }
 }

--- a/tests/Integration/OutputNormalizerTest.php
+++ b/tests/Integration/OutputNormalizerTest.php
@@ -1,16 +1,26 @@
 <?php
 
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\Integration;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\PhpExecutableFinder;
 use Webmozarts\Console\Parallelization\EnvironmentVariables;
 use function Safe\getcwd;
 
 /**
  * @covers \Webmozarts\Console\Parallelization\Integration\OutputNormalizer
+ *
+ * @internal
  */
 final class OutputNormalizerTest extends TestCase
 {
@@ -88,12 +98,12 @@ final class OutputNormalizerTest extends TestCase
 
         yield '[fixed size bar] single digit' => [
             ' 4 secs/7 secs',
-            ' 10 secs/10 secs ',
+            ' 10 secs/10 secs',
         ];
 
         yield '[fixed size bar] mixed' => [
             ' < 1 sec/18 secs',
-            ' 10 secs/10 secs ',
+            ' 10 secs/10 secs',
         ];
 
         yield 'fixed size bar' => [
@@ -126,24 +136,23 @@ final class OutputNormalizerTest extends TestCase
 
     public static function phpExecutableProvider(): iterable
     {
-        $environmentVariables = [
-            'PHP_BINARY' => 'Users/myaccount/.phpbrew/php/php-9.3.2/bin/php',
-        ];
+        $phpBinary = __DIR__.'/php-dummy';
+        $environmentVariables = ['PHP_BINARY' => $phpBinary];
 
         yield 'escaped path' => [
-            ' \'/Users/myaccount/.phpbrew/php/php-9.3.2/bin/php\' ',
+            ' \''.$phpBinary.'\' ',
             $environmentVariables,
             ' \'/path/to/php\' ',
         ];
 
         yield 'non escaped-path' => [
-            ' /Users/myaccount/.phpbrew/php/php-9.3.2/bin/php ',
+            ' '.$phpBinary.' ',
             $environmentVariables,
             ' /path/to/php ',
         ];
 
         yield 'escaped path longer path' => [
-            ' \'/Users/myaccount/.phpbrew/php/php-9.3.2/bin/php/phar\' ',
+            ' \''.$phpBinary.'/phar\' ',
             $environmentVariables,
             ' \'/path/to/php/phar\' ',
         ];
@@ -166,7 +175,7 @@ final class OutputNormalizerTest extends TestCase
         $cwd = getcwd();
 
         yield 'escaped path' => [
-            ' \'/'.$cwd.'\' ',
+            ' \''.$cwd.'\' ',
             ' \'/path/to/work-dir\' ',
         ];
 
@@ -196,11 +205,8 @@ final class OutputNormalizerTest extends TestCase
     public static function lineReturnsProvider(): iterable
     {
         yield 'linux return paths' => [
-            <<<'TXT'
-            
-            
-            TXT,
-            ' \'/path/to/work-dir\' ',
+            "\n \n",
+            "\n \n",
         ];
 
         yield 'windows return paths' => [
@@ -235,44 +241,44 @@ final class OutputNormalizerTest extends TestCase
 
         yield 'nominal without extra content' => [
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             1/5 [=====>----------------------]  20% 2 secs/10 secs 10.0 MiB
-             2/5 [===========>----------------]  40% 4 secs/10 secs 10.0 MiB
-             3/5 [================>-----------]  60% 6 secs/10 secs 10.0 MiB
-             4/5 [======================>-----]  80% 8 secs/10 secs 10.0 MiB
-             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+                 1/5 [=====>----------------------]  20% 2 secs/10 secs 10.0 MiB
+                 2/5 [===========>----------------]  40% 4 secs/10 secs 10.0 MiB
+                 3/5 [================>-----------]  60% 6 secs/10 secs 10.0 MiB
+                 4/5 [======================>-----]  80% 8 secs/10 secs 10.0 MiB
+                 5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+                TXT,
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+                 5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+                TXT,
         ];
 
         yield 'nominal with extra content' => [
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             1/5 [=====>----------------------]  20% 2 secs/10 secs 10.0 MiB [debug] smth1
-            [debug] smth2
-             2/5 [===========>----------------]  40% 4 secs/10 secs 10.0 MiB
-             3/5 [================>-----------]  60% 6 secs/10 secs 10.0 MiB[debug] smth3
-             4/5 [======================>-----]  80% 8 secs/10 secs 10.0 MiB
-             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+                 1/5 [=====>----------------------]  20% 2 secs/10 secs 10.0 MiB [debug] smth1
+                [debug] smth2
+                 2/5 [===========>----------------]  40% 4 secs/10 secs 10.0 MiB
+                 3/5 [================>-----------]  60% 6 secs/10 secs 10.0 MiB[debug] smth3
+                 4/5 [======================>-----]  80% 8 secs/10 secs 10.0 MiB
+                 5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+                TXT,
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             [debug] smth1
-            [debug] smth2
-            [debug] smth3
-             5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
+                 [debug] smth1
+                [debug] smth2
+                [debug] smth3
+                 5/5 [============================] 100% 10 secs/10 secs 10.0 MiB
+
+                TXT,
         ];
     }
 
@@ -281,9 +287,13 @@ final class OutputNormalizerTest extends TestCase
      */
     public function test_it_can_normalize_non_fixed_sized_progress_bars(
         string $output,
+        int $numberOfItems,
         string $expected
     ): void {
-        $actual = OutputNormalizer::removeIntermediateNonFixedProgressBars($output);
+        $actual = OutputNormalizer::removeIntermediateNonFixedProgressBars(
+            $output,
+            $numberOfItems,
+        );
 
         self::assertSame($expected, $actual);
     }
@@ -291,55 +301,99 @@ final class OutputNormalizerTest extends TestCase
     public static function nonFixedSizedProgressBarsProvider(): iterable
     {
         yield 'single intermediate line' => [
-            ' 4/5 [---------------------->-----]  80%  1 sec/1 sec  10.0 MiB',
+            ' 3 [---------------------->-----] 4 secs  7.0 MiB',
+            0,
             '',
         ];
 
         yield 'single intermediate line with trailing content' => [
-            ' 4/5 [---------------------->-----]  80%  1 sec/1 sec  10.0 MiB [debug] smth',
+            ' 3 [---------------------->-----] 4 secs  7.0 MiB [debug] smth',
+            0,
             ' [debug] smth',
+        ];
+
+        yield 'single intermediate line with trailing content without spacing' => [
+            ' 3 [---------------------->-----] 4 secs  7.0 MiB[debug] smth',
+            0,
+            '[debug] smth',
         ];
 
         yield 'nominal without extra content' => [
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             1/5 [----->----------------------]  20% 2 secs/10 secs 10.0 MiB
-             2/5 [----------->----------------]  40% 4 secs/10 secs 10.0 MiB
-             3/5 [---------------->-----------]  60% 6 secs/10 secs 10.0 MiB
-             4/5 [---------------------->-----]  80% 8 secs/10 secs 10.0 MiB
-             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0 [>---------------------------] < 1 sec 8.0 MiB
+                 1 [----->----------------------] 2 secs 10.0 MiB
+                 5 [----------->----------------] 4 secs 10.0 MiB
+                 6 [---------------->-----------] 6 secs 10.0 MiB
+                 9 [---------------------->-----] 8 secs 10.0 MiB
+                 12 [----------------------------] 142 secs 112.0 MiB
+
+                TXT,
+            12,
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0 [>---------------------------] < 1 sec 8.0 MiB
+                 12 [----------------------------] 142 secs 112.0 MiB
+
+                TXT,
         ];
 
-        yield 'nominal with extra content' => [
+        yield 'nominal without extra content with the cursor back to the start' => [
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             1/5 [----->----------------------]  20% 2 secs/10 secs 10.0 MiB [debug] smth1
-            [debug] smth2
-             2/5 [----------->----------------]  40% 4 secs/10 secs 10.0 MiB
-             3/5 [---------------->-----------]  60% 6 secs/10 secs 10.0 MiB[debug] smth3
-             4/5 [---------------------->-----]  80% 8 secs/10 secs 10.0 MiB
-             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0 [>---------------------------] < 1 sec 8.0 MiB
+                 1 [----->----------------------] 2 secs 10.0 MiB
+                 5 [----------->----------------] 4 secs 10.0 MiB
+                 6 [---------------->-----------] 6 secs 10.0 MiB
+                 9 [---------------------->-----] 8 secs 10.0 MiB
+                 12 [>---------------------------] 142 secs 112.0 MiB
+
+                TXT,
+            12,
             <<<'TXT'
-            
-             0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB
-             [debug] smth1
-            [debug] smth2
-            [debug] smth3
-             5/5 [----------------------------] 100% 10 secs/10 secs 10.0 MiB
 
-            TXT,
+                 0 [>---------------------------] < 1 sec 8.0 MiB
+                 12 [>---------------------------] 142 secs 112.0 MiB
+
+                TXT,
+        ];
+
+        yield 'nominal without extra content with the cursor in the middle' => [
+            <<<'TXT'
+
+                 0 [>---------------------------] < 1 sec 8.0 MiB
+                 1 [----->----------------------] 2 secs 10.0 MiB
+                 5 [----------->----------------] 4 secs 10.0 MiB
+                 6 [---------------->-----------] 6 secs 10.0 MiB
+                 9 [---------------------->-----] 8 secs 10.0 MiB
+                 12 [------------>---------------] 142 secs 112.0 MiB
+
+                TXT,
+            12,
+            <<<'TXT'
+
+                 0 [>---------------------------] < 1 sec 8.0 MiB
+                 12 [------------>---------------] 142 secs 112.0 MiB
+
+                TXT,
+        ];
+
+        yield 'buggy case #1' => [
+            <<<'TXT'
+
+                    0 [>---------------------------] 10 secs 10.0 MiB
+                    2 [->--------------------------]  10 secs 10.0 MiB
+                    4 [--->------------------------]  10 secs 10.0 MiB
+                    5 [----->----------------------]  10 secs 10.0 MiB
+
+                TXT,
+            5,
+            <<<'TXT'
+
+                    0 [>---------------------------] 10 secs 10.0 MiB
+                    5 [----->----------------------]  10 secs 10.0 MiB
+
+                TXT,
         ];
     }
 }

--- a/tests/Integration/OutputNormalizerTest.php
+++ b/tests/Integration/OutputNormalizerTest.php
@@ -444,14 +444,19 @@ final class OutputNormalizerTest extends TestCase
             ' 0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB[debug] Command started:',
         ];
 
-        yield 'standard fixed sized progress bar line with extra content with spacing' => [
+        yield 'fixed sized progress bar line with extra content with spacing' => [
             ' 0/5 [>---------------------------]   0% < 1 sec/< 1 sec 8.0 MiB [debug] Command started:',
             ' 0/5 [>---------------------------]   0% 10 secs/10 secs 10.0 MiB [debug] Command started:',
         ];
 
-        yield 'standard line with extra spacing' => [
+        yield 'fixed sized line with extra spacing' => [
             ' 5/5 [============================] 100%  1 sec/1 sec  14.0 MiB[debug] Command finished',
             ' 5/5 [============================] 100% 10 secs/10 secs 10.0 MiB[debug] Command finished',
+        ];
+
+        yield 'non fixed sized line with extra spacing' => [
+            ' 5 [----->----------------------]  10 secs 10.0 MiB',
+            ' 5 [----->----------------------] 10 secs 10.0 MiB',
         ];
     }
 }

--- a/tests/Integration/ParallelizationIntegrationTest.php
+++ b/tests/Integration/ParallelizationIntegrationTest.php
@@ -176,7 +176,7 @@ class ParallelizationIntegrationTest extends TestCase
 
         $commandTester->execute(
             [
-                'command' => 's',
+                'command' => 'import:movies-unknown-count',
                 '--processes' => '2',
             ],
             ['interactive' => true],
@@ -239,7 +239,7 @@ class ParallelizationIntegrationTest extends TestCase
             ),
         );
 
-        self::assertSame($expectedWithNoDebugMode, $outputWithoutExtraDebugInfo, $commandTester->getDisplay());
+        self::assertSame($expectedWithNoDebugMode, $outputWithoutExtraDebugInfo, $outputWithoutExtraDebugInfo);
         self::assertSame($expectedChildProcessesCount, mb_substr_count($actual, $expectedCommandStartedLine));
         self::assertSame($expectedChildProcessesCount, mb_substr_count($actual, $expectedCommandFinishedLine));
     }

--- a/tests/Integration/ParallelizationIntegrationTest.php
+++ b/tests/Integration/ParallelizationIntegrationTest.php
@@ -239,7 +239,7 @@ class ParallelizationIntegrationTest extends TestCase
             ),
         );
 
-        self::assertSame($expectedWithNoDebugMode, $outputWithoutExtraDebugInfo, $outputWithoutExtraDebugInfo);
+        self::assertSame($expectedWithNoDebugMode, $outputWithoutExtraDebugInfo, $commandTester->getDisplay());
         self::assertSame($expectedChildProcessesCount, mb_substr_count($actual, $expectedCommandStartedLine));
         self::assertSame($expectedChildProcessesCount, mb_substr_count($actual, $expectedCommandFinishedLine));
     }
@@ -370,16 +370,6 @@ class ParallelizationIntegrationTest extends TestCase
     {
         $output = $commandTester->getDisplay(true);
 
-        $output = OutputNormalizer::normalizeProgressBarTimeTaken(
-            OutputNormalizer::normalizeMemoryUsage(
-                OutputNormalizer::normalizeProjectPath(
-                    OutputNormalizer::normalizePhpExecutablePath(
-                        OutputNormalizer::normalizeLineReturns($output),
-                    ),
-                ),
-            ),
-        );
-
-        return str_replace('100%  10 secs', '100% 10 secs', $output);
+        return OutputNormalizer::normalize($output);
     }
 }

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -18,13 +18,9 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Webmozarts\Console\Parallelization\ErrorHandler\FakeErrorHandler;
 use Webmozarts\Console\Parallelization\Input\ChildCommandFactory;
 use Webmozarts\Console\Parallelization\Process\FakeProcessLauncherFactory;
-use function array_key_exists;
-use function array_keys;
-use function array_map;
 use function chr;
 use function getcwd;
 use function Safe\chdir;
-use function Safe\putenv;
 
 /**
  * @covers \Webmozarts\Console\Parallelization\ParallelExecutorFactory

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -201,7 +201,7 @@ final class ParallelExecutorFactoryTest extends TestCase
         string $expectedWorkingDirectory
     ): void {
         $cleanUpWorkingDirectory = self::moveToWorkingDirectory($workingDirectory);
-        $cleanUpEnvironmentVariables = self::setEnvironmentVariables($environmentVariables);
+        $cleanUpEnvironmentVariables = EnvironmentVariables::setVariables($environmentVariables);
 
         $expected = ParallelExecutorFactory::create(
             static fn () => ['item1', 'item2'],
@@ -275,61 +275,6 @@ final class ParallelExecutorFactoryTest extends TestCase
         chdir($workingDirectory);
 
         return static fn () => chdir($currentWorkingDirectory);
-    }
-
-    /**
-     * @param array<string, string> $environmentVariables
-     *
-     * @return callable():void
-     */
-    private static function setEnvironmentVariables(array $environmentVariables): callable
-    {
-        $restoreEnvironmentVariables = array_map(
-            static fn (string $name) => self::setEnvironmentVariable($name, $environmentVariables[$name]),
-            array_keys($environmentVariables),
-        );
-
-        return static function () use ($restoreEnvironmentVariables): void {
-            foreach ($restoreEnvironmentVariables as $restoreEnvironmentVariable) {
-                $restoreEnvironmentVariable();
-            }
-        };
-    }
-
-    /**
-     * @return callable():void
-     */
-    private static function setEnvironmentVariable(string $name, string $value): callable
-    {
-        if (array_key_exists($name, $_SERVER)) {
-            $previousValue = $_SERVER[$name];
-
-            $restoreServer = static fn () => $_SERVER[$name] = $previousValue;
-        } else {
-            $restoreServer = static function () use ($name): void {
-                unset($_SERVER[$name]);
-            };
-        }
-
-        if (array_key_exists($name, $_ENV)) {
-            $previousValue = $_ENV[$name];
-
-            $restoreEnv = static fn () => $_SERVER[$name] = $previousValue;
-        } else {
-            $restoreEnv = static function () use ($name): void {
-                unset($_ENV[$name]);
-            };
-        }
-
-        putenv($name.'='.$value);
-        $_SERVER[$name] = $value;
-        $_ENV[$name] = $value;
-
-        return static function () use ($restoreServer, $restoreEnv, $name): void {
-            putenv($name.'=');
-            $restoreServer();
-            $restoreEnv();
-        };
     }
 
     private static function createCallable(int $id): callable


### PR DESCRIPTION
Move the output normalization into a dedicated class that can be tested. This should allow to test against various variant making sure we are covering all the cases preventing random failures because we get the `>` of the progress bar at the wrong place like https://github.com/webmozarts/console-parallelization/actions/runs/3341239414/jobs/5532245319.