### PR TITLE
chore: Bump to PHP 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "7.4"
-                    - "8.0"
                     - "8.1"
                     - "8.2"
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "fidry/cpu-core-counter": "^0.4.0",
         "nikic/iter": "^2.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",


### PR DESCRIPTION
We did not have the need for PHP 7.4 internally for a while already now and 7.4 is no longer maintained so there is no point keeping it anymore.