### PR TITLE
chore: Allow CpuCoreCounter 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "fidry/cpu-core-counter": "^0.5.0",
+        "fidry/cpu-core-counter": "^0.5.0 || ^1.0",
         "nikic/iter": "^2.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.0",


### PR DESCRIPTION
Still allow 0.5 as 0.5 and 1.0 are identical and this can help one to upgrade the package meanwhile.