### PR TITLE
build: Make the default make command `help` instead of `all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
 
-.DEFAULT_GOAL := all
+.DEFAULT_GOAL := help
 
 
 # Global variables


### PR DESCRIPTION
I think this will be more useful for new contributors.