### PR TITLE
test: Move the tested Makefile output to a dedicated file

### DIFF
--- a/tests/AutoReview/MakefileTest.php
+++ b/tests/AutoReview/MakefileTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\AutoReview;
 
 use Fidry\Makefile\Test\BaseMakefileTestCase;
+use function file_get_contents;
 
 /**
  * @coversNothing
@@ -23,6 +24,8 @@ use Fidry\Makefile\Test\BaseMakefileTestCase;
  */
 final class MakefileTest extends BaseMakefileTestCase
 {
+    private const EXPECTED_OUTPUT_FILE_PATH = __DIR__.'/makefile_help_output';
+
     protected static function getMakefilePath(): string
     {
         return __DIR__.'/../../Makefile';
@@ -30,34 +33,6 @@ final class MakefileTest extends BaseMakefileTestCase
 
     protected function getExpectedHelpOutput(): string
     {
-        return <<<'EOF'
-            [33mUsage:[0m
-              make TARGET
-
-            [32m#
-            # Commands
-            #---------------------------------------------------------------------------[0m
-
-            [33mcheck:[0m 		   Runs all the checks
-            [33mcs:[0m 	 	   Fixes CS
-            [33mcs_lint:[0m	   Lints CS
-            [33mphp_cs_fixer:[0m 	   Runs PHP-CS-Fixer
-            [33mphp_cs_fixer_lint:[0m Runs PHP-CS-Fixer lint
-            [33mgitignore_sort:[0m	      Sorts the .gitignore entries
-            [33mcomposer_normalize:[0m   Normalizes the composer.json
-            [33mcomposer_normalize_lint:[0m   Lints the composer.json
-            [33mtest:[0m 	 	   Runs all the tests
-            [33mphpstan:[0m 	   Runs PHPStan
-            [33mphpunit:[0m	   Runs PHPUnit
-            [33mphpunit_infection:[0m Runs PHPUnit with code coverage for Infection
-            [33mphpunit_html:[0m	   Runs PHPUnit with code coverage with HTML report
-            [33minfection:[0m	   Runs Infection
-            [33mvalidate-package:[0m  Validates the Composer package
-            [33mclean:[0m 	  	   Removes various temporary artifacts
-            [33mclear_cache:[0m 	   Clears up the integration test app cache
-            [33mclear_coverage:[0m	   Clears up the coverage reports
-            [33mclear_dist:[0m	   Clears up dist directory
-
-            EOF;
+        return file_get_contents(self::EXPECTED_OUTPUT_FILE_PATH);
     }
 }

--- a/tests/AutoReview/makefile_help_output
+++ b/tests/AutoReview/makefile_help_output
@@ -1,0 +1,26 @@
+[33mUsage:[0m
+  make TARGET
+
+[32m#
+# Commands
+#---------------------------------------------------------------------------[0m
+
+[33mcheck:[0m 		   Runs all the checks
+[33mcs:[0m 	 	   Fixes CS
+[33mcs_lint:[0m	   Lints CS
+[33mphp_cs_fixer:[0m 	   Runs PHP-CS-Fixer
+[33mphp_cs_fixer_lint:[0m Runs PHP-CS-Fixer lint
+[33mgitignore_sort:[0m	      Sorts the .gitignore entries
+[33mcomposer_normalize:[0m   Normalizes the composer.json
+[33mcomposer_normalize_lint:[0m   Lints the composer.json
+[33mtest:[0m 	 	   Runs all the tests
+[33mphpstan:[0m 	   Runs PHPStan
+[33mphpunit:[0m	   Runs PHPUnit
+[33mphpunit_infection:[0m Runs PHPUnit with code coverage for Infection
+[33mphpunit_html:[0m	   Runs PHPUnit with code coverage with HTML report
+[33minfection:[0m	   Runs Infection
+[33mvalidate-package:[0m  Validates the Composer package
+[33mclean:[0m 	  	   Removes various temporary artifacts
+[33mclear_cache:[0m 	   Clears up the integration test app cache
+[33mclear_coverage:[0m	   Clears up the coverage reports
+[33mclear_dist:[0m	   Clears up dist directory


### PR DESCRIPTION
This allows to more easily update the expected output:

```shell
make help > tests/AutoReview/makefile_help_output
```