### PR TITLE
build: Do not comment every Make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ RECTOR = $(RECTOR_BIN)
 #---------------------------------------------------------------------------
 
 .PHONY: check
-check: 		  ## Runs all the checks
+check: 		## Runs all the checks
 check: autoreview infection
 
 .PHONY: help
@@ -53,48 +53,42 @@ help:
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
 
 .PHONY: autoreview
-autoreview: 	  ## Runs the Auto-Review checks
+autoreview: 	## Runs the Auto-Review checks
 autoreview: cs validate-package phpstan
 
 .PHONY: cs
-cs: 	 	  ## Fixes CS
+cs: 	 	## Fixes CS
 cs: php_cs_fixer gitignore_sort composer_normalize
 
 .PHONY: cs_lint
-cs_lint:	  ## Lints CS
+cs_lint:	## Lints CS
 cs_lint: php_cs_fixer_lint composer_normalize_lint
 
 .PHONY: php_cs_fixer
-php_cs_fixer: 	  ## Runs PHP-CS-Fixer
 php_cs_fixer: $(PHP_CS_FIXER_BIN)
 	$(PHP_CS_FIXER) fix
 
 .PHONY: php_cs_fixer_lint
-php_cs_fixer_lint:## Runs PHP-CS-Fixer lint
 php_cs_fixer_lint: $(PHP_CS_FIXER_BIN)
 	$(PHP_CS_FIXER) fix --dry-run
 
 .PHONY: gitignore_sort
-gitignore_sort:	     ## Sorts the .gitignore entries
 gitignore_sort:
 	LC_ALL=C sort -u .gitignore -o .gitignore
 
 .PHONY: composer_normalize
-composer_normalize:  ## Normalizes the composer.json
 composer_normalize:	vendor
 	composer normalize
 
 .PHONY: composer_normalize_lint
-composer_normalize_lint:  ## Lints the composer.json
 composer_normalize_lint:	vendor
 	composer normalize --dry-run
 
 .PHONY: test
-test: 	 	  ## Runs all the tests
+test: 	 	## Runs all the tests
 test: validate-package phpstan phpunit
 
 .PHONY: phpstan
-phpstan: 	  ## Runs PHPStan
 phpstan: phpstan_src phpstan_tests
 
 .PHONY: phpstan_src
@@ -106,23 +100,20 @@ phpstan_tests: $(PHPSTAN_BIN) vendor
 	$(PHPSTAN) analyze --configuration phpstan-tests.neon.dist
 
 .PHONY: phpunit
-phpunit:	  ## Runs PHPUnit
 phpunit: $(PHPUNIT_BIN)
 	$(PHPUNIT)
 
 .PHONY: phpunit_infection
-phpunit_infection:## Runs PHPUnit with code coverage for Infection
 phpunit_infection: $(PHPUNIT_BIN) vendor
 	$(PHPUNIT_COVERAGE_INFECTION)
 
 .PHONY: phpunit_html
-phpunit_html:	  ## Runs PHPUnit with code coverage with HTML report
+phpunit_html:	## Runs PHPUnit with code coverage with HTML report
 phpunit_html: $(PHPUNIT_BIN) vendor
 	$(PHPUNIT_COVERAGE_HTML)
 	@echo "You can check the report by opening the file \"$(COVERAGE_HTML)/index.html\"."
 
 .PHONY: infection
-infection:	  ## Runs Infection
 infection: $(INFECTION_BIN) vendor
 	$(INFECTION_WITH_INITIAL_TESTS) --initial-tests-php-options='-d zend_extension=xdebug.so'
 
@@ -131,26 +122,22 @@ _infection: $(INFECTION_BIN) $(COVERAGE_XML) $(COVERAGE_JUNIT) vendor
 	$(INFECTION)
 
 .PHONY: validate-package
-validate-package: ## Validates the Composer package
 validate-package: vendor
 	composer validate --strict
 
 .PHONY: clean
-clean: 	  	  ## Removes various temporary artifacts
+clean: 	  	## Removes various temporary artifacts
 clean: clear_cache clear_coverage clear_dist
 
 .PHONY: clear_cache
-clear_cache: 	  ## Clears up the integration test app cache
 clear_cache:
 	rm -rf tests/Integration/**/cache || true
 
 .PHONY: clear_coverage
-clear_coverage:	  ## Clears up the coverage reports
 clear_coverage:
 	rm -rf $(COVERAGE_DIR) || true
 
 .PHONY: clear_dist
-clear_dist:	  ## Clears up dist directory
 clear_dist:
 	rm -rf dist || true
 	mkdir -p dist
@@ -199,7 +186,6 @@ $(COVERAGE_JUNIT): $(PHPUNIT_BIN) $(SRC_TESTS_FILES) phpunit.xml.dist
 
 $(INFECTION_BIN): vendor
 	touch -c $@
-
 
 $(RECTOR_BIN): vendor
 	composer bin rector install

--- a/tests/AutoReview/makefile_help_output
+++ b/tests/AutoReview/makefile_help_output
@@ -5,23 +5,10 @@
 # Commands
 #---------------------------------------------------------------------------[0m
 
-[33mcheck:[0m 		   Runs all the checks
-[33mautoreview:[0m 	   Runs the Auto-Review checks
-[33mcs:[0m 	 	   Fixes CS
-[33mcs_lint:[0m	   Lints CS
-[33mphp_cs_fixer:[0m 	   Runs PHP-CS-Fixer
-[33mphp_cs_fixer_lint:[0m Runs PHP-CS-Fixer lint
-[33mgitignore_sort:[0m	      Sorts the .gitignore entries
-[33mcomposer_normalize:[0m   Normalizes the composer.json
-[33mcomposer_normalize_lint:[0m   Lints the composer.json
-[33mtest:[0m 	 	   Runs all the tests
-[33mphpstan:[0m 	   Runs PHPStan
-[33mphpunit:[0m	   Runs PHPUnit
-[33mphpunit_infection:[0m Runs PHPUnit with code coverage for Infection
-[33mphpunit_html:[0m	   Runs PHPUnit with code coverage with HTML report
-[33minfection:[0m	   Runs Infection
-[33mvalidate-package:[0m  Validates the Composer package
-[33mclean:[0m 	  	   Removes various temporary artifacts
-[33mclear_cache:[0m 	   Clears up the integration test app cache
-[33mclear_coverage:[0m	   Clears up the coverage reports
-[33mclear_dist:[0m	   Clears up dist directory
+[33mcheck:[0m 		 Runs all the checks
+[33mautoreview:[0m 	 Runs the Auto-Review checks
+[33mcs:[0m 	 	 Fixes CS
+[33mcs_lint:[0m	 Lints CS
+[33mtest:[0m 	 	 Runs all the tests
+[33mphpunit_html:[0m	 Runs PHPUnit with code coverage with HTML report
+[33mclean:[0m 	  	 Removes various temporary artifacts


### PR DESCRIPTION
The list of commands is a bit overwhelming. Ideally the help command could provide a better visibility of the "main" commands whilst still displaying the intermediate ones. But this cannot be done easily, hence it is easier to just not document them directory.