### PR TITLE
build: Execute the PHPUnit auto-review tests in a separate test suite

### DIFF
--- a/.github/workflows/auto-review.yaml
+++ b/.github/workflows/auto-review.yaml
@@ -23,6 +23,9 @@ jobs:
                     -   name: "CS"
                         command: "make cs_lint"
 
+                    -   name: "PHPUnit AutoReview"
+                        command: "make phpunit_autoreview"
+
         steps:
             -   name: "Checkout"
                 uses: "actions/checkout@v2"

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ help:
 
 .PHONY: autoreview
 autoreview: 	## Runs the Auto-Review checks
-autoreview: cs validate-package phpstan
+autoreview: cs validate-package phpstan phpunit_autoreview
 
 .PHONY: cs
 cs: 	 	## Fixes CS
@@ -101,7 +101,11 @@ phpstan_tests: $(PHPSTAN_BIN) vendor
 
 .PHONY: phpunit
 phpunit: $(PHPUNIT_BIN)
-	$(PHPUNIT)
+	$(PHPUNIT) --testsuite=Tests
+
+.PHONY: phpunit_autoreview
+phpunit_autoreview: $(PHPUNIT_BIN)
+	$(PHPUNIT) --testsuite=AutoReview
 
 .PHONY: phpunit_infection
 phpunit_infection: $(PHPUNIT_BIN) vendor

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,8 +18,12 @@
     </extensions>
 
     <testsuites>
-        <testsuite name="Test Suite">
+        <testsuite name="Tests">
             <directory>tests/</directory>
+            <exclude>tests/AutoReview</exclude>
+        </testsuite>
+        <testsuite name="AutoReview">
+            <directory>tests/AutoReview</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
Make the PHPUnit autoreview tests run for the make `autoreview` command rather than `test`.