### PR TITLE
ci: Make the output more pretty

### DIFF
--- a/.github/workflows/auto-review.yaml
+++ b/.github/workflows/auto-review.yaml
@@ -35,7 +35,15 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     tools: "composer"
-                    coverage: "none"
+
+            -   name: "Install Composer dependencies"
+                uses: "ramsey/composer-install@v2"
+
+            -   name: "Install PHP-CS-Fixer dependencies"
+                if: "${{ matrix.name == 'PHPStan' }}"
+                uses: "ramsey/composer-install@v2"
+                with:
+                    working-directory: vendor-bin/php-cs-fixer
 
             -   name: "Run ${{ matrix.check.name }}"
                 run: "${{ matrix.check.command }}"

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,11 @@ phpstan_tests: $(PHPSTAN_BIN) vendor
 
 .PHONY: phpunit
 phpunit: $(PHPUNIT_BIN)
-	$(PHPUNIT) --testsuite=Tests
+	$(PHPUNIT) --testsuite=Tests --colors=always
 
 .PHONY: phpunit_autoreview
 phpunit_autoreview: $(PHPUNIT_BIN)
-	$(PHPUNIT) --testsuite=AutoReview
+	$(PHPUNIT) --testsuite=AutoReview --colors=always
 
 .PHONY: phpunit_infection
 phpunit_infection: $(PHPUNIT_BIN) vendor


### PR DESCRIPTION
- Ensure the installation step happens outside of the `make` command.
- Execute PHPUnit with colours