### PR TITLE
build: Tweak the rector configuration

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -13,13 +13,18 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
+        __DIR__.'/.php-cs-fixer.php',
+        __DIR__.'/rector.php',
         __DIR__.'/src',
         __DIR__.'/tests',
     ]);
+
+    $rectorConfig->importNames();
 
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
@@ -27,7 +32,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip([
         CountOnNullRector::class,
-        \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class => [
+        NullToStrictStringFuncCallArgRector::class => [
             __DIR__.'/src/ParallelExecutorFactory.php',
             __DIR__.'/tests/Integration/OutputNormalizer.php',
         ],


### PR DESCRIPTION
- Ensure the rector and PHP-CS-Fixer config files are checked by rector.
- Ensure the class names are imported.