### PR TITLE
ci: Fix the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
                     - "*"
 
     -   package-ecosystem: "composer"
-        directory: "requirement-checker"
+        directory: "vendor-bin"
         schedule:
             interval: "weekly"
         groups:


### PR DESCRIPTION
Thsi directory `requirement-checker` does not exists, it is a leftover from a copy I did. The intended directory that it should be pointing at is `vendor-bin`.