### PR TITLE
test: Fix flaky test

### DIFF
--- a/tests/Process/CpuCoreCounterTest.php
+++ b/tests/Process/CpuCoreCounterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Process;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Webmozarts\Console\Parallelization\EnvironmentVariables;
 
 /**
@@ -23,6 +24,11 @@ use Webmozarts\Console\Parallelization\EnvironmentVariables;
  */
 final class CpuCoreCounterTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        self::removeCachedCount();
+    }
+
     /**
      * @backupGlobals
      */
@@ -46,5 +52,13 @@ final class CpuCoreCounterTest extends TestCase
         $cleanUp();
 
         self::assertSame(7, $cpuCoresCount);
+    }
+
+    private static function removeCachedCount(): void
+    {
+        $reflectionClass = new ReflectionClass(CpuCoreCounter::class);
+        $countReflection = $reflectionClass->getProperty('count');
+        $countReflection->setAccessible(true);
+        $countReflection->setValue(CpuCoreCounter::class, null);
     }
 }


### PR DESCRIPTION
The counter test was due to the random order, which could result in the count to be cached with a different value than the one expected.