### PR TITLE
test: Fix the PHPunit reset CPU counter listener

### DIFF
--- a/phpstan-tests.neon.dist
+++ b/phpstan-tests.neon.dist
@@ -11,7 +11,6 @@ parameters:
         - tests/Process/DummyProcess.php
         - tests/Process/DummyProcess74.php
         - tests/Process/DummyProcess81.php
-        - tests/PHPUnit/ResetCpuCounterListener.php
     ignoreErrors:
         - path: tests/Integration/TestLogger.php
           message: '#TestLogger::\$outputHandler#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,8 +14,8 @@
     </php>
 
     <extensions>
-        <extension class="Webmozarts\Console\Parallelization\PHPUnit\ResetCpuCounterListener"/>
-        <extension class="Webmozarts\StrictPHPUnit\StrictPHPUnitExtension"/>
+        <bootstrap class="Webmozarts\Console\Parallelization\PHPUnit\PHPUnitExtension"/>
+        <bootstrap class="Webmozarts\StrictPHPUnit\StrictPHPUnitExtension"/>
     </extensions>
 
     <testsuites>

--- a/tests/PHPUnit/PHPUnitExtension.php
+++ b/tests/PHPUnit/PHPUnitExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\PHPUnit;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class PHPUnitExtension implements Extension
+{
+    public function bootstrap(
+        Configuration $configuration,
+        Facade $facade,
+        ParameterCollection $parameters
+    ): void {
+        $facade->registerSubscriber(new ResetCpuCounterSubscriber());
+    }
+}

--- a/tests/PHPUnit/ResetCpuCounterSubscriber.php
+++ b/tests/PHPUnit/ResetCpuCounterSubscriber.php
@@ -13,16 +13,17 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\PHPUnit;
 
-use PHPUnit\Runner\AfterTestHook;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
 use ReflectionClass;
 use ReflectionProperty;
 use Webmozarts\Console\Parallelization\Process\CpuCoreCounter;
 
-final class ResetCpuCounterListener implements AfterTestHook
+final class ResetCpuCounterSubscriber implements PreparationStartedSubscriber
 {
     private static ?ReflectionProperty $countReflection = null;
 
-    public function executeAfterTest(string $test, float $time): void
+    public function notify(PreparationStarted $event): void
     {
         self::resetCounter();
     }

--- a/tests/Process/CpuCoreCounterTest.php
+++ b/tests/Process/CpuCoreCounterTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Webmozarts\Console\Parallelization\Process;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use Webmozarts\Console\Parallelization\EnvironmentVariables;
 
 /**
@@ -24,10 +23,7 @@ use Webmozarts\Console\Parallelization\EnvironmentVariables;
  */
 final class CpuCoreCounterTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        self::removeCachedCount();
-    }
+    // Note that no teardown is necessary; we leverage the ResetCpuCounterSubscriber.
 
     /**
      * @backupGlobals
@@ -52,13 +48,5 @@ final class CpuCoreCounterTest extends TestCase
         $cleanUp();
 
         self::assertSame(7, $cpuCoresCount);
-    }
-
-    private static function removeCachedCount(): void
-    {
-        $reflectionClass = new ReflectionClass(CpuCoreCounter::class);
-        $countReflection = $reflectionClass->getProperty('count');
-        $countReflection->setAccessible(true);
-        $countReflection->setValue(new CpuCoreCounter(), null);
     }
 }


### PR DESCRIPTION
With PHPUnit 10 the listener API changed. This is what caused the failures such as:

```
1) Webmozarts\Console\Parallelization\Process\CpuCoreCounterTest::test_can_get_the_number_of_cpu_cores_defined
Failed asserting that 2 is identical to 7.
```

I attempted to fix this in #256, forgetting that this listener existed. This PR reverts #256 and migrate the listener to the PHPUnit 10 extension + subscriber system.