### PR TITLE
fix: Do not prepend the working directory for the script path when the script path is an absolute path

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,6 +7,7 @@ require __DIR__.'/../vendor/autoload.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\DependencyInjection\Container;
+use Webmozarts\Console\Parallelization\Fixtures\Command\AbsoluteScriptPathCommand;
 use Webmozarts\Console\Parallelization\Fixtures\Command\ImportMoviesCommand;
 use Webmozarts\Console\Parallelization\Fixtures\Command\ImportUnknownMoviesCountCommand;
 use Webmozarts\Console\Parallelization\Fixtures\Command\LegacyCommand;
@@ -22,5 +23,6 @@ $application->add(new ImportMoviesCommand());
 $application->add(new ImportUnknownMoviesCountCommand());
 $application->add(new LegacyCommand());
 $application->add(new NoSubProcessCommand());
+$application->add(new AbsoluteScriptPathCommand());
 
 $application->run();

--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -341,7 +341,8 @@ final class ParallelExecutorFactory
         $scriptName = $_SERVER['SCRIPT_NAME'];
 
         return (str_starts_with($scriptName, $pwd)
-                || str_starts_with($scriptName, DIRECTORY_SEPARATOR))
+                || str_starts_with($scriptName, DIRECTORY_SEPARATOR)
+        )
             ? $scriptName
             : $pwd.DIRECTORY_SEPARATOR.$scriptName;
     }

--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -340,7 +340,8 @@ final class ParallelExecutorFactory
         $pwd = $_SERVER['PWD'];
         $scriptName = $_SERVER['SCRIPT_NAME'];
 
-        return str_starts_with($scriptName, $pwd)
+        return (str_starts_with($scriptName, $pwd)
+                || str_starts_with($scriptName, DIRECTORY_SEPARATOR))
             ? $scriptName
             : $pwd.DIRECTORY_SEPARATOR.$scriptName;
     }

--- a/tests/Fixtures/Command/AbsoluteScriptPathCommand.php
+++ b/tests/Fixtures/Command/AbsoluteScriptPathCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Webmozarts\Console\Parallelization\Fixtures\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozarts\Console\Parallelization\ParallelCommand;
+use Webmozarts\Console\Parallelization\ParallelExecutorFactory;
+use function range;
+
+final class AbsoluteScriptPathCommand extends ParallelCommand
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $batchMovies;
+
+    public function __construct()
+    {
+        parent::__construct('absolute-script-path');
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function fetchItems(InputInterface $input, OutputInterface $output): array
+    {
+        return range(0, 3);
+    }
+
+    protected function configureParallelExecutableFactory(ParallelExecutorFactory $parallelExecutorFactory, InputInterface $input, OutputInterface $output): ParallelExecutorFactory
+    {
+        return $parallelExecutorFactory
+            ->withBatchSize(2)
+            ->withSegmentSize(2);
+        //        return $parallelExecutorFactory
+        //            ->withScriptPath(__DIR__.'/../../../bin/console');
+    }
+
+    protected function runSingleCommand(string $item, InputInterface $input, OutputInterface $output): void
+    {
+        // Do nothing
+    }
+
+    protected function getItemName(?int $count): string
+    {
+        return 1 === $count ? 'item' : 'items';
+    }
+}

--- a/tests/Fixtures/Command/AbsoluteScriptPathCommand.php
+++ b/tests/Fixtures/Command/AbsoluteScriptPathCommand.php
@@ -17,7 +17,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozarts\Console\Parallelization\ParallelCommand;
 use Webmozarts\Console\Parallelization\ParallelExecutorFactory;
+use function array_map;
 use function range;
+use function strval;
 
 final class AbsoluteScriptPathCommand extends ParallelCommand
 {
@@ -31,7 +33,10 @@ final class AbsoluteScriptPathCommand extends ParallelCommand
      */
     protected function fetchItems(InputInterface $input, OutputInterface $output): array
     {
-        return range(0, 3);
+        return array_map(
+            strval(...),
+            range(0, 3),
+        );
     }
 
     protected function configureParallelExecutableFactory(ParallelExecutorFactory $parallelExecutorFactory, InputInterface $input, OutputInterface $output): ParallelExecutorFactory

--- a/tests/Fixtures/Command/AbsoluteScriptPathCommand.php
+++ b/tests/Fixtures/Command/AbsoluteScriptPathCommand.php
@@ -21,11 +21,6 @@ use function range;
 
 final class AbsoluteScriptPathCommand extends ParallelCommand
 {
-    /**
-     * @var array<string, string>
-     */
-    private array $batchMovies;
-
     public function __construct()
     {
         parent::__construct('absolute-script-path');
@@ -44,8 +39,6 @@ final class AbsoluteScriptPathCommand extends ParallelCommand
         return $parallelExecutorFactory
             ->withBatchSize(2)
             ->withSegmentSize(2);
-        //        return $parallelExecutorFactory
-        //            ->withScriptPath(__DIR__.'/../../../bin/console');
     }
 
     protected function runSingleCommand(string $item, InputInterface $input, OutputInterface $output): void


### PR DESCRIPTION
Rebased version of #252 with a test.

Closes #252.
Closes #223.