### PR TITLE
fix: Remove hooks API deprecations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,15 +34,6 @@
     - `::getSegmentSize()`
     - `::getBatchSize()`
     - `::getConsolePath()`
-- As part of the previous point, the following methods will no longer be declared
-  in the `Parallelization` trait in 3.0. It is perfectly fine to still have a
-  method with those names, but you need to register them to the factory (it will
-  no longer be done automatically in 3.0) and you should not extend the current
-  ones. The following methods are affected:
-    - `::runBeforeFirstCommand()`
-    - `::runAfterLastCommand()`
-    - `::runBeforeBatch()`
-    - `::runAfterBatch()`
 - The following methods have been removed from `Parallelization` and have no
   replacement (the existing and new extension points should be enough to cover
   those):

--- a/src/Parallelization.php
+++ b/src/Parallelization.php
@@ -372,24 +372,12 @@ trait Parallelization
         ];
     }
 
-    /**
-     * @deprecated Deprecated since 2.0.0 and will be removed in 3.0.0. Override
-     *             ::getParallelExecutableFactory() to register your own callable. Note that having
-     *             a method with the same name is still fine, but it needs to be registered to the
-     *             factory and not extend the original one.
-     */
     protected function runBeforeFirstCommand(
         InputInterface $input,
         OutputInterface $output
     ): void {
     }
 
-    /**
-     * @deprecated Deprecated since 2.0.0 and will be removed in 3.0.0. Override
-     *             ::getParallelExecutableFactory() to register your own callable. Note that having
-     *             a method with the same name is still fine, but it needs to be registered to the
-     *             factory and not extend the original one.
-     */
     protected function runAfterLastCommand(
         InputInterface $input,
         OutputInterface $output
@@ -397,11 +385,6 @@ trait Parallelization
     }
 
     /**
-     * @deprecated Deprecated since 2.0.0 and will be removed in 3.0.0. Override
-     *             ::getParallelExecutableFactory() to register your own callable. Note that having
-     *             a method with the same name is still fine, but it needs to be registered to the
-     *             factory and not extend the original one.
-     *
      * @param list<string> $items
      */
     protected function runBeforeBatch(
@@ -412,11 +395,6 @@ trait Parallelization
     }
 
     /**
-     * @deprecated Deprecated since 2.0.0 and will be removed in 3.0.0. Override
-     *             ::getParallelExecutableFactory() to register your own callable. Note that having
-     *             a method with the same name is still fine, but it needs to be registered to the
-     *             factory and not extend the original one.
-     *
      * @param list<string> $items
      */
     protected function runAfterBatch(


### PR DESCRIPTION
This part of the API should not be deprecated. The idea of `ParallelCommand` is to provide a leaner and alternative API, not to replace the `Parallelization` trait.

A number of configuration methods are and should remain deprecated as they can now be easily configured via
`configureParallelExecutableFactory()` instead*.

*: the interest here is not so much to provide a difference from a user perspective, but rather to have one central point of customization, the `ParallelExecutorFactory`. Otherwise if we add/change a setting there we need to change it both in the factory and the trait.