### PR TITLE
fix: Remove incorrect deprecations trigger

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,6 +48,8 @@
 - `::getItemName()` can now take `null` for an unknown number of items
 - Ensures that if an item is given, then the processing is done in the main
   process. An item also cannot be passed to a child process (via the argument).
+- The working directory changed from being the `kernel.project_dir` parameter for
+  child processes to be the same as the main process.
 
 
 ## New extension points

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,8 +48,6 @@
 - `::getItemName()` can now take `null` for an unknown number of items
 - Ensures that if an item is given, then the processing is done in the main
   process. An item also cannot be passed to a child process (via the argument).
-- The working directory changed from being the `kernel.project_dir` parameter for
-  child processes to be the same as the main process.
 
 
 ## New extension points

--- a/src/ParallelCommand.php
+++ b/src/ParallelCommand.php
@@ -112,6 +112,9 @@ abstract class ParallelCommand extends Command
     }
 
     /**
+     * Note that for configuring the ParallelExecutorFactory it is more likely simpler to use
+     *  `::configureParallelExecutableFactory()`.
+     *
      * @param callable(InputInterface):iterable<string>              $fetchItems
      * @param callable(string, InputInterface, OutputInterface):void $runSingleCommand
      * @param callable(positive-int|0|null):string                   $getItemName


### PR DESCRIPTION
Previously if a user was using the `Parallelization` trait, the only way they had to get rid of the deprecation notices triggered was to override `getParallelExecutableFactory()`. This is not ideal as we recommend to override `configureParallelExecutableFactory()` instead.

This PR moves the deprecations to `::configureParallelExecutableFactory()`.