### PR TITLE
fix: Fix incorrect PHP executable escaping

### DIFF
--- a/src/ParallelExecutorFactory.php
+++ b/src/ParallelExecutorFactory.php
@@ -24,7 +24,6 @@ use Webmozarts\Console\Parallelization\Process\ProcessLauncherFactory;
 use Webmozarts\Console\Parallelization\Process\StandardSymfonyProcessFactory;
 use Webmozarts\Console\Parallelization\Process\SymfonyProcessLauncherFactory;
 use function chr;
-use function explode;
 use function is_string;
 use function Safe\getcwd;
 use function str_starts_with;
@@ -232,16 +231,12 @@ final class ParallelExecutorFactory
      * The path of the PHP executable. It is the executable that will be used
      * to spawn the child process(es).
      *
-     * @param string|list<string> $phpExecutable
+     * @param string|list<string> $phpExecutable e.g. ['/path/to/php', '-dmemory_limit=512M']
      */
     public function withPhpExecutable(string|array $phpExecutable): self
     {
-        $normalizedExecutable = is_string($phpExecutable)
-            ? explode(' ', $phpExecutable)
-            : $phpExecutable;
-
         $clone = clone $this;
-        $clone->phpExecutable = $normalizedExecutable;
+        $clone->phpExecutable = is_string($phpExecutable) ? [$phpExecutable] : $phpExecutable;
 
         return $clone;
     }

--- a/tests/Input/ChildCommandFactoryTest.php
+++ b/tests/Input/ChildCommandFactoryTest.php
@@ -270,6 +270,31 @@ final class ChildCommandFactoryTest extends TestCase
             ];
         })();
 
+        yield 'enriched PHP executable with space (array case)' => (static function () use (
+            $scriptPath,
+            $commandName
+        ) {
+            [$input, $commandDefinition] = self::createInput(
+                [],
+                [],
+            );
+
+            return [
+                ['/path/to/my php', '-dmemory_limit=1'],
+                $scriptPath,
+                $commandName,
+                $commandDefinition,
+                $input,
+                [
+                    '/path/to/my php',
+                    '-dmemory_limit=1',
+                    $scriptPath,
+                    $commandName,
+                    '--child',
+                ],
+            ];
+        })();
+
         yield 'no PHP executable or command' => (static function () use (
             $scriptPath
         ) {


### PR DESCRIPTION
Having the following `/path/to/my php -dmemory_limit=512M` was not working. The string variant can be kept but I think should be kept to the most basic usage, for anything else an array should be used.