### PR TITLE
test: Fix PHPUnit data provider providing more data than necessary

### DIFF
--- a/tests/ParallelExecutorTest.php
+++ b/tests/ParallelExecutorTest.php
@@ -168,7 +168,6 @@ final class ParallelExecutorTest extends TestCase
                         [$input, $output, [$items[2]]],
                     ],
                 ],
-                [],
             ];
         })();
 
@@ -209,7 +208,6 @@ final class ParallelExecutorTest extends TestCase
                         [$input, $output, ['item1']],
                     ],
                 ],
-                [],
             ];
         })();
 
@@ -236,7 +234,6 @@ final class ParallelExecutorTest extends TestCase
                 $progressSymbol,
                 $createExpectedOutput(0),
                 0,
-                [],
                 [],
             ];
         })();
@@ -308,7 +305,6 @@ final class ParallelExecutorTest extends TestCase
                         [$input, $output, [$items[2]]],
                     ],
                 ],
-                [],
             ];
         })();
     }


### PR DESCRIPTION
It is an issue since
https://github.com/sebastianbergmann/phpunit/pull/6213 and those cases were legit.