### PR TITLE
test: Fix the closure comparisons

### DIFF
--- a/src/Input/ParallelizationInput.php
+++ b/src/Input/ParallelizationInput.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Webmozarts\Console\Parallelization\Input;
 
+use Closure;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -38,6 +39,11 @@ final class ParallelizationInput
         self::MAIN_PROCESS_OPTION,
         self::CHILD_OPTION,
     ];
+
+    /**
+     * @var Closure():positive-int
+     */
+    private static Closure $defaultValidatedNumberOfProcessesClosure;
 
     /**
      * @var positive-int
@@ -100,7 +106,7 @@ final class ParallelizationInput
         } else {
             $validatedNumberOfProcesses = null !== $numberOfProcesses
                 ? self::coerceNumberOfProcesses($numberOfProcesses)
-                : static fn () => CpuCoreCounter::getNumberOfCpuCores();
+                : self::getDefaultValidatedNumberOfProcessesClosure();
         }
 
         if ($isChild) {
@@ -177,6 +183,18 @@ final class ParallelizationInput
                 InputOption::VALUE_REQUIRED,
                 'Set the segment size.',
             );
+    }
+
+    /**
+     * @return Closure():positive-int
+     */
+    public static function getDefaultValidatedNumberOfProcessesClosure(): Closure
+    {
+        if (!isset(self::$defaultValidatedNumberOfProcessesClosure)) {
+            self::$defaultValidatedNumberOfProcessesClosure = static fn () => CpuCoreCounter::getNumberOfCpuCores();
+        }
+
+        return self::$defaultValidatedNumberOfProcessesClosure;
     }
 
     public function shouldBeProcessedInMainProcess(): bool

--- a/tests/Input/ParallelizationInputTest.php
+++ b/tests/Input/ParallelizationInputTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
-use Webmozarts\Console\Parallelization\Process\CpuCoreCounter;
 
 /**
  * @internal
@@ -153,13 +152,11 @@ final class ParallelizationInputTest extends TestCase
 
     public static function inputProvider(): iterable
     {
-        $findNumberOfProcesses = static fn () => CpuCoreCounter::getNumberOfCpuCores();
-
         yield 'empty input' => [
             new StringInput(''),
             new ParallelizationInput(
                 false,
-                $findNumberOfProcesses,
+                ParallelizationInput::getDefaultValidatedNumberOfProcessesClosure(),
                 null,
                 false,
                 null,
@@ -231,7 +228,7 @@ final class ParallelizationInputTest extends TestCase
             new StringInput('--child'),
             new ParallelizationInput(
                 false,
-                $findNumberOfProcesses,
+                ParallelizationInput::getDefaultValidatedNumberOfProcessesClosure(),
                 null,
                 true,
                 null,
@@ -267,7 +264,7 @@ final class ParallelizationInputTest extends TestCase
             new StringInput('--batch-size=10'),
             new ParallelizationInput(
                 false,
-                $findNumberOfProcesses,
+                ParallelizationInput::getDefaultValidatedNumberOfProcessesClosure(),
                 null,
                 false,
                 10,
@@ -279,7 +276,7 @@ final class ParallelizationInputTest extends TestCase
             new StringInput('--segment-size=10'),
             new ParallelizationInput(
                 false,
-                $findNumberOfProcesses,
+                ParallelizationInput::getDefaultValidatedNumberOfProcessesClosure(),
                 null,
                 false,
                 null,

--- a/tests/ParallelExecutorFactoryTest.php
+++ b/tests/ParallelExecutorFactoryTest.php
@@ -271,10 +271,14 @@ final class ParallelExecutorFactoryTest extends TestCase
         $cleanUpWorkingDirectory = self::moveToWorkingDirectory($workingDirectory);
         $cleanUpEnvironmentVariables = EnvironmentVariables::setVariables($environmentVariables);
 
+        $fetchItems = static fn () => ['item1', 'item2'];
+        $runSingleCommand = static fn () => '';
+        $getItemName = static fn () => 'item';
+
         $expected = ParallelExecutorFactory::create(
-            static fn () => ['item1', 'item2'],
-            static fn () => '',
-            static fn () => 'item',
+            $fetchItems,
+            $runSingleCommand,
+            $getItemName,
             'import:movies',
             new InputDefinition(),
             new FakeErrorHandler(),
@@ -286,9 +290,9 @@ final class ParallelExecutorFactoryTest extends TestCase
             ->build();
 
         $actual = ParallelExecutorFactory::create(
-            static fn () => ['item1', 'item2'],
-            static fn () => '',
-            static fn () => 'item',
+            $fetchItems,
+            $runSingleCommand,
+            $getItemName,
             'import:movies',
             new InputDefinition(),
             new FakeErrorHandler(),


### PR DESCRIPTION
Those failures were caused since `sebastian/comparator 7.1.0`.

See https://github.com/sebastianbergmann/comparator/issues/129.