### PR TITLE
test: Prevent the Symfony error handler to be registered while executing tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          cacheDirectory="dist/phpunit-cache"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          beStrictAboutChangesToGlobalState="true"
          beStrictAboutOutputDuringTests="true"
          colors="true"
@@ -22,6 +22,7 @@
             <directory>tests/</directory>
             <exclude>tests/AutoReview</exclude>
         </testsuite>
+
         <testsuite name="AutoReview">
             <directory>tests/AutoReview</directory>
         </testsuite>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Webmozarts Console Parallelization package.
+ *
+ * (c) Webmozarts GmbH <office@webmozarts.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+// Workaround for https://github.com/symfony/symfony/issues/53812
+// The problem is that FrameworkBundle registers an error handler but does not have a way to unregister it.
+// The issue was closed, so we probably need to use the workaround until newer Symfony/PHPUnit versions fix it,
+// or we use the regular Symfony WebTestCase instead of our custom WebRouteTestCase.
+// The current setup code in FrameworkBundle will check if `ErrorHandler` is already registered and won't register it again.
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+require __DIR__.'/../vendor/autoload.php';
+
+ErrorHandler::register();


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/53812.